### PR TITLE
Remove undeeded scripts

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -74,9 +74,6 @@ class PageController extends Controller {
 		$this->initialStateService->provideInitialState($this->appName, 'maps', $this->config->getAppValue('maps', 'enabled', 'no') === 'yes');
 
 
-		// used by the sidebar to parse files requests
-		// TODO: move to a standalone dav fileinfo parser
-		Util::addScript('files', 'files/client');
 		Util::addScript($this->appName, 'photos');
 		Util::addStyle($this->appName, 'icons');
 

--- a/src/main.js
+++ b/src/main.js
@@ -47,11 +47,13 @@ Vue.prototype.t = translate
 Vue.prototype.n = translatePlural
 
 // TODO: remove when we have a proper fileinfo standalone library
+// original scripts are loaded from
+// https://github.com/nextcloud/server/blob/5bf3d1bb384da56adbf205752be8f840aac3b0c5/lib/private/legacy/template.php#L120-L122
 window.addEventListener('DOMContentLoaded', () => {
-	// register unused client for the sidebar to have access to its parser methods
 	if (!window.OCA.Files) {
 		window.OCA.Files = {}
 	}
+	// register unused client for the sidebar to have access to its parser methods
 	Object.assign(window.OCA.Files, { App: { fileList: { filesClient: OC.Files.getClient() } } }, window.OCA.Files)
 })
 


### PR DESCRIPTION
We apparently load the needed scripts on every page already thanks to https://github.com/nextcloud/server/blob/5bf3d1bb384da56adbf205752be8f840aac3b0c5/lib/private/legacy/template.php#L120-L122

That is terrible :see_no_evil: 