### PR TITLE
Respect .noimage and .nomedia files

### DIFF
--- a/lib/Controller/AlbumsController.php
+++ b/lib/Controller/AlbumsController.php
@@ -142,6 +142,11 @@ class AlbumsController extends Controller {
 			return [];
 		}
 
+		// Ignore folder with a .noimage or .nomedia node
+		if ($folder->nodeExists('.noimage') || $folder->nodeExists('.nomedia')) {
+			return [];
+		}
+
 		$nodes = $folder->getDirectoryListing();
 
 		foreach ($nodes as $node) {


### PR DESCRIPTION
Fixes #75

When a folder has a .noimage or .nomedia node. Just don't show the
folder in the album overview. Ignore it and do not traverse it.

Signed-off-by: Roeland Jago Douma <roeland@famdouma.nl>