### PR TITLE
Allow heic images in the photos overview

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -33,6 +33,7 @@ class Application extends App {
 	const MIMES = [
 		// 'image/png',			// too rarely used for photos
 		'image/jpeg',
+		'image/heic',
 		// 'image/gif',			// too rarely used for photos
 		// 'image/x-xbitmap',	// too rarely used for photos
 		// 'image/bmp',			// too rarely used for photos


### PR DESCRIPTION
Fix #311 
All we have to do is setup the backend with HEIC support (Imagemagick + libheif). Then the backend handles the preview generation for the thumbnails.

As a prerequisite this requires https://github.com/nextcloud/viewer/pull/485 in the viewer component.

Signed-off-by: Sebastian Steinmetz <462714+steiny2k@users.noreply.github.com>