### PR TITLE
WIP:  timeline server supporting features

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,6 +10,10 @@
 <author mail="skjnldsv@protonmail.com">John Molakvoæ</author>
 <namespace>Photos</namespace>
 <category>multimedia</category>
+<types>
+	<filesystem/>
+	<dav/>
+</types>
 
 <website>https://github.com/nextcloud/photos</website>
 <bugs>https://github.com/nextcloud/photos/issues</bugs>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -1,28 +1,32 @@
 <?xml version="1.0"?>
 <info xmlns:xsi= "http://www.w3.org/2001/XMLSchema-instance"
-      xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
-    <id>photos</id>
-    <name>Photos</name>
-    <summary>Your memories under your control</summary>
-    <description>Your memories under your control</description>
-    <version>1.3.0</version>
-    <licence>agpl</licence>
-	<author mail="skjnldsv@protonmail.com">John Molakvoæ</author>
-    <namespace>Photos</namespace>
-    <category>multimedia</category>
+	xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
+<id>photos</id>
+<name>Photos</name>
+<summary>Your memories under your control</summary>
+<description>Your memories under your control</description>
+<version>1.3.0</version>
+<licence>agpl</licence>
+<author mail="skjnldsv@protonmail.com">John Molakvoæ</author>
+<namespace>Photos</namespace>
+<category>multimedia</category>
 
-	<website>https://github.com/nextcloud/photos</website>
-	<bugs>https://github.com/nextcloud/photos/issues</bugs>
-    <repository>https://github.com/nextcloud/photos.git</repository>
-    <default_enable />
-    <dependencies>
-        <nextcloud min-version="21" max-version="21" />
-    </dependencies>
-    <navigations>
-        <navigation>
-            <name>Photos</name>
-            <route>photos.page.index</route>
-            <order>1</order>
-        </navigation>
-    </navigations>
+<website>https://github.com/nextcloud/photos</website>
+<bugs>https://github.com/nextcloud/photos/issues</bugs>
+<repository>https://github.com/nextcloud/photos.git</repository>
+<default_enable />
+<dependencies>
+	<nextcloud min-version="20" max-version="21" />
+</dependencies>
+<navigations>
+	<navigation>
+		<name>Photos</name>
+		<route>photos.page.index</route>
+		<order>1</order>
+	</navigation>
+</navigations>
+<commands>
+	<command>OCA\Photos\Command\ExtractMetadata</command>
+</commands>
+
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 <name>Photos</name>
 <summary>Your memories under your control</summary>
 <description>Your memories under your control</description>
-<version>1.3.0</version>
+<version>1.3.1</version>
 <licence>agpl</licence>
 <author mail="skjnldsv@protonmail.com">John Molakvoæ</author>
 <namespace>Photos</namespace>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -73,5 +73,30 @@ return [
 				'path' => '',
 			],
 		],
+		[
+			'name' => 'albums#getNumberByMonth',
+			'url' => '/api/v1/numberbymonth/{path}',
+			'verb' => 'GET',
+			'requirements' => [
+				'path' => '.*',
+			],
+			'defaults' => [
+				'path' => '',
+			],
+		],
+		[
+			'name' => 'albums#getPhotosOfMonth',
+			'url' => '/api/v1/photosofmonth/{path}',
+			'verb' => 'GET',
+			'requirements' => [
+				'yearandmonth' => '.*',
+				'path' => '.*',
+			],
+			'defaults' => [
+				'yearandmonth' => '',
+				'path' => '',
+			],
+		],
+
 	]
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -86,7 +86,7 @@ return [
 		],
 		[
 			'name' => 'albums#getPhotosOfMonth',
-			'url' => '/api/v1/photosofmonth/{path}',
+			'url' => '/api/v1/photosofmonth/{yearandmonth}',
 			'verb' => 'GET',
 			'requirements' => [
 				'yearandmonth' => '.*',

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -52,11 +52,13 @@ class Application extends App implements IBootstrap {
 
 	public function __construct() {
 		parent::__construct(self::APP_ID);
+				
 	}
 
 	public function register(IRegistrationContext $context): void {
 	}
 
 	public function boot(IBootContext $context): void {
+		\OCP\Util::connectHook('OC_Filesystem', 'preSetup', 'OCA\Photos\Storage', 'setupStorage');
 	}
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -29,6 +29,7 @@ use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
+use OCP\Files\Events\NodeAddedToCache;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'photos';
@@ -52,7 +53,12 @@ class Application extends App implements IBootstrap {
 
 	public function __construct() {
 		parent::__construct(self::APP_ID);
-				
+		/* @var IEventDispatcher $eventDispatcher */
+		$dispatcher = $this->getContainer()->get("OCP\EventDispatcher\IEventDispatcher" );
+		$dispatcher->addListener(NodeAddedToCache::class, function(NodeAddedToCache $event) {
+			$filePath = $event->getPath();
+		});
+
 	}
 
 	public function register(IRegistrationContext $context): void {

--- a/lib/Command/ExtractMetadata.php
+++ b/lib/Command/ExtractMetadata.php
@@ -159,7 +159,10 @@ class ExtractMetadata extends Command {
 		}
 		$mimeType = \OC::$server->getMimeTypeDetector()->detectPath($file->getPath());
 		if (in_array($mimeType, ['image/jpeg'])) {
-			$photoMetadata = $this->metadataService->extractPhotoMetadata($file);
+			$fileStorage = $file->getStorage();
+    	$tempStream = $fileStorage->fopen($file->getInternalPath(),'r');
+			$photoMetadata = $this->metadataService->extractPhotoMetadata($tempStream,$file->getId());
+			fclose($tempStream);
 			$this->photoMetadataMapper->insert($photoMetadata);
 		}
 	}

--- a/lib/Command/ExtractMetadata.php
+++ b/lib/Command/ExtractMetadata.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+
+
+namespace OCA\Photos\Command;
+
+use OCP\Encryption\IManager;
+use OCP\Files\File;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotFoundException;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IUserManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use OCA\Photos\Db\PhotoMetadata;
+use OCA\Photos\Db\PhotoMetadataMapper;
+use OCA\Photos\Service\MetadataService;
+
+class ExtractMetadata extends Command {
+
+	/** @var IUserManager */
+	protected $userManager;
+
+	/** @var IRootFolder */
+	protected $rootFolder;
+
+	/** @var IConfig */
+	protected $config;
+
+	/** @var OutputInterface */
+	protected $output;
+
+	/** @var IManager */
+	protected $encryptionManager;
+
+	/** @var PhotoMetadataMapper */
+	private $photoMetadataMapper;
+
+	/** @var MetadataService */
+	private $metadataService;
+
+	public function __construct(IRootFolder $rootFolder,
+		IUserManager $userManager,
+		IConfig $config,
+		IManager $encryptionManager,
+		PhotoMetadataMapper $photoMetadataMapper,
+		MetadataService $metadataService) {
+		parent::__construct();
+
+		$this->userManager = $userManager;
+		$this->rootFolder = $rootFolder;
+		$this->config = $config;
+		$this->encryptionManager = $encryptionManager;
+		$this->photoMetadataMapper = $photoMetadataMapper;
+		$this->metadataService = $metadataService;
+	}
+
+	protected function configure() {
+		$this
+			->setName('photos:extractmetadata')
+			->setDescription('extract metadata from image files: date taken, location...')
+			->addArgument(
+				'user_id',
+				InputArgument::OPTIONAL,
+				'extract photo metadata for the given user'
+			)->addOption(
+				'path',
+				'p',
+				InputOption::VALUE_OPTIONAL,
+				'limit extraction to this photo folder(album), eg. --path="/alice/files/Photos/2020-3/", the user_id is determined by the path and the user_id parameter is ignored'
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		if ($this->encryptionManager->isEnabled()) {
+			$output->writeln('Encryption is enabled. Aborted.');
+			return 1;
+		}
+
+		$this->output = $output;
+
+		$inputPath = $input->getOption('path');
+		if ($inputPath) {
+			$inputPath = '/' . trim($inputPath, '/');
+			list (, $userId,) = explode('/', $inputPath, 3);
+			$user = $this->userManager->get($userId);
+			if ($user !== null) {
+				$this->extractPathPhotosMetadata($user, $inputPath);
+			}
+		} else {
+			$userId = $input->getArgument('user_id');
+			if ($userId === null) {
+				$this->userManager->callForSeenUsers(function (IUser $user) {
+					$this->extractUserPhotosMetadata($user);
+				});
+			} else {
+				$user = $this->userManager->get($userId);
+				if ($user !== null) {
+					$this->extractUserPhotosMetadata($user);
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	private function extractPathPhotosMetadata(IUser $user, string $path) {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($user->getUID());
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		try {
+			$relativePath = $userFolder->getRelativePath($path);
+		} catch (NotFoundException $e) {
+			$this->output->writeln('Path not found');
+			return;
+		}
+		$pathFolder = $userFolder->get($relativePath);
+		$this->parseFolder($pathFolder);
+	}
+
+	private function extractUserPhotosMetadata(IUser $user) {
+		\OC_Util::tearDownFS();
+		\OC_Util::setupFS($user->getUID());
+
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$this->parseFolder($userFolder);
+
+	}
+
+	private function parseFolder(Folder $folder) {
+		// Respect the '.nomedia' file. If present don't traverse the folder
+		if ($folder->nodeExists('.nomedia')) {
+			$this->output->writeln('Skipping folder ' . $folder->getPath());
+			return;
+		}
+
+		$this->output->writeln('Scanning folder ' . $folder->getPath());
+
+		$nodes = $folder->getDirectoryListing();
+
+		foreach ($nodes as $node) {
+			if ($node instanceof Folder) {
+				$this->parseFolder($node);
+			} else if ($node instanceof File) {
+				$this->parseFile($node);
+			}
+		}
+	}
+
+	private function parseFile(File $file) {
+		if ($this->output->getVerbosity() > OutputInterface::VERBOSITY_VERBOSE) {
+			$this->output->writeln('Extracting metadata from  ' . $file->getPath());
+		}
+		$mimeType = \OC::$server->getMimeTypeDetector()->detectPath($file->getPath());
+		if (in_array($mimeType, ['image/jpeg'])) {
+			$photoMetadata = $this->metadataService->extractPhotoMetadata($file);
+			$this->photoMetadataMapper->insert($photoMetadata);
+		}
+	}
+
+}
+

--- a/lib/Db/PhotoMetadata.php
+++ b/lib/Db/PhotoMetadata.php
@@ -1,0 +1,36 @@
+<?php
+namespace OCA\Photos\Db;
+
+use JsonSerializable;
+
+use OCP\AppFramework\Db\Entity;
+
+class PhotoMetadata extends Entity implements JsonSerializable {
+
+    protected $fileId;
+    protected $dateTimeOriginal;
+		protected $gpsLatitude;
+		protected $gpsLongitude;
+		protected $gpsLatitudeRef;
+		protected $gpsLongitudeRef;
+		protected $path;
+
+    public function __construct() {
+			$this->addType('id','integer');
+			$this->addType('fileId','integer');
+     }
+
+    public function jsonSerialize() {
+        return [
+            'id' => $this->id,
+            'dateTimeOriginal' => $this->dateTimeOriginal,
+            'gpsLatitude' => $this->gpsLatitude,
+						'gpsLongitude' => $this->gpsLongitude,
+						'gpsLatitudeRefl' => $this->gpsLatitudeRef,
+						'gpsLongitudeRef'  => $this->gpsLongitudeRef,
+						'path' => $this->path,
+        ];
+    }
+}
+
+?>

--- a/lib/Db/PhotoMetadataMapper.php
+++ b/lib/Db/PhotoMetadataMapper.php
@@ -1,0 +1,50 @@
+<?php
+// db/FileCacheMapper.php
+
+namespace OCA\Photos\Db;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\AppFramework\Db\DoesNotExistException;
+
+class PhotoMetadataMapper extends QBMapper {
+
+  private $table_name = 'photosmetadata';
+
+  public function __construct(IDBConnection $db) {
+    parent::__construct($db, $this->table_name,PhotoMetadata::class);
+  }
+
+  public function find(int $fileId){
+    $qb = $this->db->getQueryBuilder();
+
+    $qb->select('*')
+       ->from($this->table_name)
+       ->where(
+         $qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT))
+       );
+    try{
+      return $this->findEntity($qb);
+    }catch(DoesNotExistException $e){
+      return null;
+    }
+
+  }
+  /**
+   * @throws \OCP\AppFramework\Db\DoesNotExistException if not found
+   *
+   *  @param array $fileIds
+   */
+  public function findAll(array $fileIds) {
+    $qb = $this->db->getQueryBuilder();
+
+    $qb->select('*')
+       ->from($this->table_name);
+
+		$filesMetadata = $this->findEntities($qb);
+		return array_filter($filesMetadata, function($fileMetadata) use ($fileIds) {
+			return in_array($fileMetadata->getFileId(),$fileIds);
+		});
+  }
+}

--- a/lib/Migration/Version000000Date20201002183800.php
+++ b/lib/Migration/Version000000Date20201002183800.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace OCA\Photos\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Migration\IOutput;
+
+class Version000000Date20201002183800 extends SimpleMigrationStep
+{
+
+  /**
+    * @param IOutput $output
+    * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+    * @param array $options
+    * @return null|ISchemaWrapper
+  */
+  public function changeSchema(IOutput $output, Closure $schemaClosure, array $options)
+  {
+    /** @var ISchemaWrapper $schema */
+    $schema = $schemaClosure();
+    $tableName = "photosmetadata";
+    if (!$schema->hasTable($tableName)) {
+      $table = $schema->createTable($tableName);
+      $table->addColumn('id', 'integer', [
+				'notnull' => true,
+				'autoincrement' => true,
+				'unsigned' => true,
+      ]);
+		 
+			$table->addColumn('file_id', 'integer', [
+				'notnull' => true,
+				'unsigned' => true,
+        'length' => 64,
+      ]);
+			$table->addColumn('date_time_original', 'string', [
+        'notnull' => false,
+        'length' => 200
+      ]);
+      $table->addColumn('gps_latitude', 'string', [
+        'notnull' => false,
+      ]);
+      $table->addColumn('gps_longitude', 'string', [
+        'notnull' => false
+      ]);
+      $table->addColumn('gps_latitude_ref', 'string', [
+        'notnull' => false
+      ]);
+      $table->addColumn('gps_longitude_ref', 'string', [
+        'notnull' => false
+      ]);
+			
+			$table->addColumn('path', 'string', [
+        'notnull' => false
+      ]);
+
+
+      $table->setPrimaryKey(['id']);
+    }
+    return $schema;
+  }
+}

--- a/lib/Migration/Version000000Date20201002183800.php
+++ b/lib/Migration/Version000000Date20201002183800.php
@@ -26,12 +26,10 @@ class Version000000Date20201002183800 extends SimpleMigrationStep
       $table->addColumn('id', 'integer', [
 				'notnull' => true,
 				'autoincrement' => true,
-				'unsigned' => true,
       ]);
 		 
 			$table->addColumn('file_id', 'integer', [
-				'notnull' => true,
-				'unsigned' => true,
+				'notnull' => false,
         'length' => 64,
       ]);
 			$table->addColumn('date_time_original', 'string', [

--- a/lib/Service/MetadataService.php
+++ b/lib/Service/MetadataService.php
@@ -1,0 +1,37 @@
+<?php
+namespace OCA\Photos\Service;
+
+use OCA\Photos\Db\PhotoMetadata;
+use OCP\Files\File;
+
+class MetadataService {
+	
+	public function __construct() {
+	}
+
+	public function extractPhotoMetadata(File $file): PhotoMetadata {
+    $fileStorage = $file->getStorage();
+    $tempStream = $fileStorage->fopen($file->getInternalPath(),'r');
+		$metadata = exif_read_data($tempStream);
+		fclose($tempStream);
+		$metadata = [
+			'DateTimeOriginal' => $metadata['DateTimeOriginal'] ?? "",
+			'GPSLatitude' => implode('-',$metadata['GPSLatitude']) ?? "",
+			'GPSLongitude' => implode('-',$metadata['GPSLongitude']) ?? "",
+			'GPSLatitudeRef' => $metadata['GPSLatitudeRef'] ?? "",
+			'GPSLongitudeRef' => $metadata['GPSLongitudeRef'] ?? ""
+		];
+		// save metadatat to database
+		$photoMetadata = new PhotoMetadata();
+		$photoMetadata->setFileId($file->getId());
+		$photoMetadata->setDateTimeOriginal($metadata['DateTimeOriginal']);
+		$photoMetadata->setGpsLatitude($metadata['GPSLatitude']);
+		$photoMetadata->setGpsLongitude($metadata['GPSLongitude']);
+		$photoMetadata->setGpsLatitudeRef($metadata['GPSLatitudeRef']);
+		$photoMetadata->setGpsLongitudeRef($metadata['GPSLongitudeRef']);
+		return $photoMetadata;
+	}
+}
+
+
+?>

--- a/lib/Service/MetadataService.php
+++ b/lib/Service/MetadataService.php
@@ -9,11 +9,8 @@ class MetadataService {
 	public function __construct() {
 	}
 
-	public function extractPhotoMetadata(File $file): PhotoMetadata {
-    $fileStorage = $file->getStorage();
-    $tempStream = $fileStorage->fopen($file->getInternalPath(),'r');
-		$metadata = exif_read_data($tempStream);
-		fclose($tempStream);
+	public function extractPhotoMetadata($stream, int $fileId=-1): PhotoMetadata {
+		$metadata = exif_read_data($stream);
 		$metadata = [
 			'DateTimeOriginal' => $metadata['DateTimeOriginal'] ?? "",
 			'GPSLatitude' => implode('-',$metadata['GPSLatitude']) ?? "",
@@ -23,7 +20,7 @@ class MetadataService {
 		];
 		// save metadatat to database
 		$photoMetadata = new PhotoMetadata();
-		$photoMetadata->setFileId($file->getId());
+		$photoMetadata->setFileId($fileId);
 		$photoMetadata->setDateTimeOriginal($metadata['DateTimeOriginal']);
 		$photoMetadata->setGpsLatitude($metadata['GPSLatitude']);
 		$photoMetadata->setGpsLongitude($metadata['GPSLongitude']);

--- a/lib/Storage.php
+++ b/lib/Storage.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ *
+ * @author Bjoern Schiessle <bjoern@schiessle.org>
+ * @author Björn Schießle <bjoern@schiessle.org>
+ * @author Christoph Wurst <christoph@winzerhof-wurst.at>
+ * @author Julius Härtl <jus@bitgrid.net>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Robin Appelman <robin@icewind.nl>
+ * @author Roeland Jago Douma <roeland@famdouma.nl>
+ * @author Vincent Petry <pvince81@owncloud.com>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Photos;
+
+use OC\Files\Filesystem;
+use OC\Files\Storage\Wrapper\Wrapper;
+use OCA\Files_Trashbin\Events\MoveToTrashEvent;
+use OCA\Files_Trashbin\Trash\ITrashManager;
+use OCP\Encryption\Exceptions\GenericEncryptionException;
+use OCP\Files\IRootFolder;
+use OCP\Files\Mount\IMountPoint;
+use OCP\Files\Node;
+use OCP\ILogger;
+use OCP\IUserManager;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+class Storage extends Wrapper {
+	/** @var IMountPoint */
+	private $mountPoint;
+
+	/** @var  IUserManager */
+	private $userManager;
+
+	/** @var ILogger */
+	private $logger;
+
+	/** @var EventDispatcherInterface */
+	private $eventDispatcher;
+
+	/** @var IRootFolder */
+	private $rootFolder;
+
+	/** @var ITrashManager */
+	private $trashManager;
+
+	/**
+	 * Storage constructor.
+	 *
+	 * @param array $parameters
+	 * @param ITrashManager $trashManager
+	 * @param IUserManager|null $userManager
+	 * @param ILogger|null $logger
+	 * @param EventDispatcherInterface|null $eventDispatcher
+	 * @param IRootFolder|null $rootFolder
+	 */
+	public function __construct(
+		$parameters,
+		ITrashManager $trashManager = null,
+		IUserManager $userManager = null,
+		ILogger $logger = null,
+		EventDispatcherInterface $eventDispatcher = null,
+		IRootFolder $rootFolder = null
+	) {
+		$this->mountPoint = $parameters['mountPoint'];
+		$this->trashManager = $trashManager;
+		$this->userManager = $userManager;
+		$this->logger = $logger;
+		$this->eventDispatcher = $eventDispatcher;
+		$this->rootFolder = $rootFolder;
+		parent::__construct($parameters);
+	}
+
+	/**
+	 * Setup the storate wrapper callback
+	 */
+	public static function setupStorage() {
+		\OC\Files\Filesystem::addStorageWrapper('oc_photos', function ($mountPoint, $storage) {
+			return new \OCA\Photos\Storage(
+				['storage' => $storage, 'mountPoint' => $mountPoint],
+				\OC::$server->query(ITrashManager::class),
+				\OC::$server->getUserManager(),
+				\OC::$server->getLogger(),
+				\OC::$server->getEventDispatcher(),
+				\OC::$server->getLazyRootFolder()
+			);
+		}, 1);
+	}
+
+	public function getMountPoint() {
+		return $this->mountPoint;
+	}
+}


### PR DESCRIPTION
add metadata to photos own database for fast timeline info query 
**following changes are added :**
1. add migration to store the metadata
```
MariaDB [nextcloud]> describe oc_photosmetadata;
+--------------------+--------------+------+-----+---------+----------------+
| Field              | Type         | Null | Key | Default | Extra          |
+--------------------+--------------+------+-----+---------+----------------+
| id                 | int(11)      | NO   | PRI | NULL    | auto_increment |
| file_id            | int(11)      | YES  |     | NULL    |                |
| date_time_original | varchar(200) | YES  |     | NULL    |                |
| gps_latitude       | varchar(255) | YES  |     | NULL    |                |
| gps_longitude      | varchar(255) | YES  |     | NULL    |                |
| gps_latitude_ref   | varchar(255) | YES  |     | NULL    |                |
| gps_longitude_ref  | varchar(255) | YES  |     | NULL    |                |
| path               | varchar(255) | YES  |     | NULL    |                |
+--------------------+--------------+------+-----+---------+----------------+
```
2. add command to extract existing file metadata 
```
root@1bd5f6fc3e6b:/var/www/html# sudo  -u www-data ./occ photos: -h
Description:
  extract metadata from image files: date taken, location...

Usage:
  photos:extractmetadata [options] [--] [<user_id>]

Arguments:
  user_id               extract photo metadata for the given user

Options:
  -p, --path[=PATH]     limit extraction to this photo folder(album), eg. --path="/alice/files/Photos/2020-3/", the user_id is determined by the path and the user_id parameter is ignored
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
      --no-warnings     Skip global warnings, show command output only
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
```

3.  get user all photos number by month 
```
curl -k -i -H "Accept: application/json" -H "Content-Type: application/json" -H "Cookie: __Host-nc_sameSiteCookielax=true; __Host-nc_sameSiteCookiestrict=true; nc_sameSiteCookielax=true; nc_sameSiteCookiestrict=true; nc_username=danny; nc_token=3%2BCLyVRqpUGwCbany%2FU7odzUSbTF9dC6; nc_session_id=qdlk3gnb3muuugbjblcemn1kks; XDEBUG_SESSION=XDEBUG_ECLIPSE; ocf6hkhrls8q=d630f3ea256da534b4100395a049482c; oc_sessionPassphrase=jhoszO87UjcudUSvNi3%2F9NgNTz7qApJKS%2FFFYehpMknbInUPKT0Peh4VcISB%2BxsKTr4ctsa%2FxlnF8q4c9xXBy6IgmX4fTIdDHfssFp%2FfJRY8EMe6MH4zdocLhxfm8mF8; ocandbbmzjpq=7eecd010120f174d305855aee443a227; JSESSIONID=B57788520C0C2995DA0C3A28FCAD7DCC; ocjjjzdb39no=qdlk3gnb3muuugbjblcemn1kks" -H "requesttoken: Jr7wkdepIYQSGSNpBfy4aE9pf6zL5LA6E7e5P8GztZ8=:bfampJPsd6tZQGcPU8jqJjUPUNapjMFXSYDTZarS2dc=" https://localhost/index.php/apps/photos/api/v1/numberbymonth
HTTP/1.1 200 OK
Server: nginx
Date: Tue, 06 Oct 2020 16:41:06 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 378
Connection: keep-alive
Vary: Accept-Encoding
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Content-Security-Policy: default-src 'none';base-uri 'none';manifest-src 'self'
Referrer-Policy: no-referrer
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Robots-Tag: none
X-XSS-Protection: 1; mode=block
Feature-Policy: autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone 'none';payment 'none'
Strict-Transport-Security: max-age=31536000; includeSubDomains

{"unknown":15,"2014-Sep":11,"2015-Oct":7,"2016-Jun":2,"2016-Jul":20,"2016-Aug":26,"2016-Oct":29,"2017-Mar":40,"2017-Apr":34,"2017-Jul":1,"2015-Mar":14,"2015-May":12,"2018-Aug":4,"2018-Oct":2,"2015-Jul":1,"2015-Aug":1,"2015-Sep":2,"2015-Dec":1,"2016-Feb":3,"2016-Mar":5,"2016-May":1,"2016-Sep":44,"2016-Nov":1,"2016-Dec":16,"2017-Jan":38,"2017-Feb":13,"2017-May":24,"2018-Sep":2}
```
4 add  API to get  list of file ids of one specific month 
```
 curl -k -i -H "Accept: application/json" -H "Content-Type: application/json" -H "Cookie: __Host-nc_sameSiteCookielax=true; __Host-nc_sameSiteCookiestrict=true; nc_sameSiteCookielax=true; nc_sameSiteCookiestrict=true; nc_username=danny; nc_token=3%2BCLyVRqpUGwCbany%2FU7odzUSbTF9dC6; nc_session_id=qdlk3gnb3muuugbjblcemn1kks; XDEBUG_SESSION=XDEBUG_ECLIPSE; ocf6hkhrls8q=d630f3ea256da534b4100395a049482c; oc_sessionPassphrase=jhoszO87UjcudUSvNi3%2F9NgNTz7qApJKS%2FFFYehpMknbInUPKT0Peh4VcISB%2BxsKTr4ctsa%2FxlnF8q4c9xXBy6IgmX4fTIdDHfssFp%2FfJRY8EMe6MH4zdocLhxfm8mF8; ocandbbmzjpq=7eecd010120f174d305855aee443a227; JSESSIONID=B57788520C0C2995DA0C3A28FCAD7DCC; ocjjjzdb39no=qdlk3gnb3muuugbjblcemn1kks" -H "requesttoken: Jr7wkdepIYQSGSNpBfy4aE9pf6zL5LA6E7e5P8GztZ8=:bfampJPsd6tZQGcPU8jqJjUPUNapjMFXSYDTZarS2dc=" https://localhost/index.php/apps/photos/api/v1/photosofmonth/2016-08
HTTP/1.1 200 OK
Server: nginx
Date: Tue, 06 Oct 2020 16:42:19 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 157
Connection: keep-alive
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-cache, no-store, must-revalidate
Pragma: no-cache
Content-Security-Policy: default-src 'none';base-uri 'none';manifest-src 'self'
Referrer-Policy: no-referrer
X-Content-Type-Options: nosniff
X-Download-Options: noopen
X-Frame-Options: SAMEORIGIN
X-Permitted-Cross-Domain-Policies: none
X-Robots-Tag: none
X-XSS-Protection: 1; mode=block
Feature-Policy: autoplay 'none';camera 'none';fullscreen 'none';geolocation 'none';microphone 'none';payment 'none'
Strict-Transport-Security: max-age=31536000; includeSubDomains

[14380,14271,14388,14282,14681,14688,14690,14698,14691,14755,14733,14710,14753,14736,14756,14757,14759,14758,14761,14760,14764,14762,14763,14765,14769,14768]
```
**TODO:**
extract photo metadata during upload, pending server pull request : [23230](https://github.com/nextcloud/server/pull/23230)