### PR TITLE
Add option to display specific directory only

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,4 +25,8 @@
             <order>1</order>
         </navigation>
     </navigations>
+    <settings>
+        <personal>OCA\Photos\Settings\Personal</personal>
+        <personal-section>OCA\Photos\Settings\PersonalSection</personal-section>
+    </settings>
 </info>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -23,6 +23,7 @@
 
 return [
 	'routes' => [
+		['name' => 'api#getUserConfig', 'url' => '/api/v1/config/{key}', 'verb' => 'GET'],
 		['name' => 'api#setUserConfig', 'url' => '/api/v1/config/{key}', 'verb' => 'PUT'],
 
 		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,19 @@
+$('#photos_dir').on('click', function () {
+	OC.dialogs.filepicker(
+		t('photos', 'Select a folder to use in Photo app'),
+		function (path) {
+			$('#photos_dir').val(path);
+
+			$.ajax({
+				url: OC.generateUrl('apps/photos/api/v1/config/photos_dir'),
+				type: 'PUT',
+				data: {value: path},
+				success: function(data) {OC.Notification.showTemporary(t('photos', 'saved')); },
+				error: function(data) {OC.Notification.showTemporary(t('photos', 'Error saving setting')); },
+			});
+		},
+		false,
+		'httpd/unix-directory',
+		true
+	);
+});

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -53,6 +53,26 @@ class ApiController extends Controller {
 	/**
 	 * @NoAdminRequired
 	 *
+	 * get preferences (user setting)
+	 *
+	 * @param string key the identifier
+	 *
+	 * @return JSONResponse with result in value
+	 */
+	public function getUserConfig(string $key): JSONResponse {
+		$user = $this->userSession->getUser();
+		if (is_null($user)) {
+			return new JSONResponse([], Http::STATUS_PRECONDITION_FAILED);
+		}
+
+		$userId = $user->getUid();
+		$value = $this->config->getUserValue($userId, Application::APP_ID, $key, '');
+		return new JSONResponse(['value' => $value], Http::STATUS_OK);
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
 	 * update preferences (user setting)
 	 *
 	 * @param string key the identifier to change

--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -85,6 +85,7 @@ class PageController extends Controller {
 		$this->initialStateService->provideInitialState($this->appName, 'image-mimes', Application::IMAGE_MIMES);
 		$this->initialStateService->provideInitialState($this->appName, 'video-mimes', Application::VIDEO_MIMES);
 		$this->initialStateService->provideInitialState($this->appName, 'maps', $this->appManager->isEnabledForUser('maps') === true);
+		$this->initialStateService->provideInitialState($this->appName, 'photos_dir', $this->config->getUserValue($user->getUid(), Application::APP_ID, 'photos_dir', ''));
 		$this->initialStateService->provideInitialState($this->appName, 'croppedLayout', $this->config->getUserValue($user->getUid(), Application::APP_ID, 'croppedLayout', 'false'));
 
 		Util::addScript(Application::APP_ID, 'photos-main');

--- a/lib/Settings/Personal.php
+++ b/lib/Settings/Personal.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ * @author Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Settings;
+
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\IConfig;
+use OCP\Settings\ISettings;
+
+/**
+ * @since 9.1
+ */
+class Personal implements ISettings {
+	private $userId;
+	private $configManager;
+
+	public function __construct(
+		$userId,
+		IConfig $configManager
+	) {
+		$this->userId = $userId;
+		$this->configManager = $configManager;
+	}
+
+	/**
+	 * @return TemplateResponse returns the instance with all parameters set, ready to be rendered
+	 * @since 9.1
+	 */
+	public function getForm() {
+		$parameters = [
+			'photos_dir'=> $this->configManager->getUserValue($this->userId, 'photos', 'photos_dir', '')
+		];
+
+		return  new TemplateResponse('photos', 'settings', $parameters);
+	}
+
+	/**
+	 * @return string the section ID, e.g. 'sharing'
+	 * @since 9.1
+	 */
+	public function getSection() {
+		return 'photos';
+	}
+
+	/**
+	 * @return int whether the form should be rather on the top or bottom of
+	 * the admin section. The forms are arranged in ascending order of the
+	 * priority values. It is required to return a value between 0 and 100.
+	 *
+	 * E.g.: 70
+	 * @since 9.1
+	 */
+	public function getPriority() {
+		return 50;
+	}
+}

--- a/lib/Settings/PersonalSection.php
+++ b/lib/Settings/PersonalSection.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @copyright Copyright (c) 2016 Arthur Schiwon <blizzz@arthur-schiwon.de>
+ *
+ * @author Arthur Schiwon <blizzz@arthur-schiwon.de>
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Lukas Reschke <lukas@statuscode.ch>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Settings;
+
+use OCP\IL10N;
+use OCP\IURLGenerator;
+use OCP\Settings\IIconSection;
+
+/**
+ * @deprecated 12 Use IIconSection instead
+ * @since 9.1
+ */
+class PersonalSection implements IIconSection {
+	/** @var IL10N */
+	private $l;
+	/** @var IURLGenerator */
+	private $url;
+
+	/**
+	 * @param IURLGenerator $url
+	 * @param IL10N $l
+	 */
+	public function __construct(IURLGenerator $url, IL10N $l) {
+		$this->url = $url;
+		$this->l = $l;
+	}
+
+	/**
+	 * returns the ID of the section. It is supposed to be a lower case string,
+	 * e.g. 'ldap'
+	 *
+	 * @returns string
+	 * @since 9.1
+	 */
+	public function getID() {
+		return 'photos';
+	}
+
+	/**
+	 * returns the translated name as it should be displayed, e.g. 'LDAP / AD
+	 * integration'. Use the L10N service to translate it.
+	 *
+	 * @return string
+	 * @since 9.1
+	 */
+	public function getName() {
+		return $this->l->t('Photos');
+	}
+
+	/**
+	 * @return int whether the form should be rather on the top or bottom of
+	 * the settings navigation. The sections are arranged in ascending order of
+	 * the priority values. It is required to return a value between 0 and 99.
+	 *
+	 * E.g.: 70
+	 * @since 9.1
+	 */
+	public function getPriority() {
+		return 50;
+	}
+
+	public function getIcon() {
+		return $this->url->imagePath('photos', 'yourphotos.svg');
+	}
+}

--- a/src/Photos.vue
+++ b/src/Photos.vue
@@ -31,7 +31,7 @@
 					exact />
 				<AppNavigationItem to="/videos" :title="t('photos', 'Your videos')" icon="icon-video" />
 				<AppNavigationItem to="/favorites" :title="t('photos', 'Favorites')" icon="icon-favorite" />
-				<AppNavigationItem :to="{name: 'albums'}" :title="t('photos', 'Your folders')" icon="icon-files-dark" />
+				<AppNavigationItem :to="'/albums/' + photosDirWithoutLeadingSlash" :title="t('photos', 'Your folders')" icon="icon-files-dark" />
 				<AppNavigationItem :to="{name: 'shared'}" :title="t('photos', 'Shared with you')" icon="icon-share" />
 				<AppNavigationItem :to="{name: 'tags'}" :title="t('photos', 'Tagged photos')" icon="icon-tag" />
 				<AppNavigationItem v-if="showLocationMenuEntry"
@@ -73,6 +73,7 @@ import svgplaceholder from './assets/file-placeholder.svg'
 import imgplaceholder from './assets/image.svg'
 import videoplaceholder from './assets/video.svg'
 import isMapsInstalled from './services/IsMapsInstalled'
+import photosDir from './services/PhotosDir'
 
 export default {
 	name: 'Photos',
@@ -93,6 +94,7 @@ export default {
 			showLocationMenuEntry: getCurrentUser() === null
 				? false
 				: getCurrentUser().isAdmin || isMapsInstalled,
+			photosDirWithoutLeadingSlash: photosDir.startsWith('/') ? photosDir.substr(1) : photosDir,
 		}
 	},
 }

--- a/src/services/PhotoSearch.js
+++ b/src/services/PhotoSearch.js
@@ -26,6 +26,8 @@ import { allMimes } from './AllowedMimes'
 import client from './DavClient'
 import { props } from './DavRequest'
 import { sizes } from '../assets/grid-sizes'
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
 
 /**
  * List files from a folder and filter out unwanted mimes
@@ -47,6 +49,9 @@ export default async function(onlyFavorites = false, options = {}) {
 	}, options)
 
 	const prefixPath = `/files/${getCurrentUser().uid}`
+
+	const targetPathRead = await axios.get(generateUrl('apps/photos/api/v1/config/photos_dir'))
+	const targetPath = targetPathRead.data.value + (targetPathRead.data.value.endsWith('/') ? '' : '/')
 
 	// generating the search or condition
 	// based on the allowed mimetypes
@@ -127,5 +132,6 @@ export default async function(onlyFavorites = false, options = {}) {
 		.map(data => genFileInfo(data))
 		// remove prefix path from full file path
 		.map(data => Object.assign({}, data, { filename: data.filename.replace(prefixPath, '') }))
+		.filter(data => data.filename.startsWith(targetPath))
 
 }

--- a/src/services/PhotosDir.js
+++ b/src/services/PhotosDir.js
@@ -1,0 +1,4 @@
+import { loadState } from '@nextcloud/initial-state'
+
+const photosDir = loadState('photos', 'photos_dir')
+export default photosDir

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -1,0 +1,9 @@
+<?php
+
+script('photos', 'settings');
+
+?>
+<div class="section">
+	<h2><?php p($l->t('Photos')); ?></h2>
+	<?php p($l->t('Directory for use in Photo app')); ?>: <input type="text" id="photos_dir" value="<?php p($_['photos_dir']); ?>" />
+</div>


### PR DESCRIPTION
I tried to address #141 .

In this pull request, user can set one directory to use in photo app, and photos app shows within the directory by default.

Search method is not very efficient, but it at least works in a simple way. I tried to limit scope in WebDAV search, but failed with an error.

I was not sure how you build `js/photos-*` for pushing to this directory, I kept them as is for now. For testing I used `make build-js`.

I'm not sure about coding styles here, so if you find something not fitting this repository, please comment.