### PR TITLE
allow image/x-dcraw (eg .cr2) in photos

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -37,6 +37,7 @@ class Application extends App implements IBootstrap {
 		'image/png',
 		'image/jpeg',
 		'image/heic',
+		'image/x-dcraw'
 		// 'image/gif',			// too rarely used for photos
 		// 'image/x-xbitmap',	// too rarely used for photos
 		// 'image/bmp',			// too rarely used for photos


### PR DESCRIPTION
This fixes #530.
.cr2 files are now availabe in photos. 