### PR TITLE
Provide better grid on photos

### DIFF
--- a/src/components/File.vue
+++ b/src/components/File.vue
@@ -149,7 +149,8 @@ img {
 
 	color: transparent; // should be diplayed on error
 
-	object-fit: contain;
+	object-fit: cover;
+	object-position: top;
 
 	.file--cropped & {
 		object-fit: cover;


### PR DESCRIPTION
As Photos is mainly used on...photos, this should provide the best grid view IMO.

Before 
![image](https://user-images.githubusercontent.com/12234510/132950656-e39971a0-3546-450b-9ff8-fe0a05fa9956.png)

After
![image](https://user-images.githubusercontent.com/12234510/132950686-0636bbfd-b3c4-4cd3-8627-7215c59940c1.png)
