### PR TITLE
Album dav api

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -10,6 +10,9 @@
 	<author mail="skjnldsv@protonmail.com">John Molakvoæ</author>
     <namespace>Photos</namespace>
     <category>multimedia</category>
+	<types>
+		<dav/>
+	</types>
 
 	<website>https://github.com/nextcloud/photos</website>
 	<bugs>https://github.com/nextcloud/photos/issues</bugs>
@@ -25,4 +28,10 @@
             <order>1</order>
         </navigation>
     </navigations>
+
+	<sabre>
+		<collections>
+			<collection>OCA\Photos\Sabre\RootCollection</collection>
+		</collections>
+	</sabre>
 </info>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,5 +33,8 @@
 		<collections>
 			<collection>OCA\Photos\Sabre\RootCollection</collection>
 		</collections>
+		<plugins>
+			<plugin>OCA\Photos\Sabre\Album\PropFindPlugin</plugin>
+		</plugins>
 	</sabre>
 </info>

--- a/lib/Album/AlbumFile.php
+++ b/lib/Album/AlbumFile.php
@@ -27,11 +27,24 @@ class AlbumFile {
 	private int $fileId;
 	private string $name;
 	private string $mimeType;
+	private int $size;
+	private int $mtime;
+	private string $etag;
 
-	public function __construct(int $fileId, string $name, string $mimeType) {
+	public function __construct(
+		int $fileId,
+		string $name,
+		string $mimeType,
+		int $size,
+		int $mtime,
+		string $etag
+	) {
 		$this->fileId = $fileId;
 		$this->name = $name;
 		$this->mimeType = $mimeType;
+		$this->size = $size;
+		$this->mtime = $mtime;
+		$this->etag = $etag;
 	}
 
 	public function getFileId(): int {
@@ -44,5 +57,17 @@ class AlbumFile {
 
 	public function getMimeType(): string {
 		return $this->mimeType;
+	}
+
+	public function getSize(): int {
+		return $this->size;
+	}
+
+	public function getMTime(): int {
+		return $this->mtime;
+	}
+
+	public function getEtag() {
+		return $this->etag;
 	}
 }

--- a/lib/Album/AlbumFile.php
+++ b/lib/Album/AlbumFile.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Album;
+
+class AlbumFile {
+	private int $fileId;
+	private string $name;
+	private string $mimeType;
+
+	public function __construct(int $fileId, string $name, string $mimeType) {
+		$this->fileId = $fileId;
+		$this->name = $name;
+		$this->mimeType = $mimeType;
+	}
+
+	public function getFileId(): int {
+		return $this->fileId;
+	}
+
+	public function getName(): string {
+		return $this->name;
+	}
+
+	public function getMimeType(): string {
+		return $this->mimeType;
+	}
+}

--- a/lib/Album/AlbumFile.php
+++ b/lib/Album/AlbumFile.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace OCA\Photos\Album;
 
+use OC\Metadata\FileMetadata;
+
 class AlbumFile {
 	private int $fileId;
 	private string $name;
@@ -30,6 +32,8 @@ class AlbumFile {
 	private int $size;
 	private int $mtime;
 	private string $etag;
+	/** @var array<int, FileMetadata> */
+	private array $metaData = [];
 
 	public function __construct(
 		int $fileId,
@@ -69,5 +73,17 @@ class AlbumFile {
 
 	public function getEtag() {
 		return $this->etag;
+	}
+
+	public function setMetadata(string $key, FileMetadata $value): void {
+		$this->metaData[$key] = $value;
+	}
+
+	public function hasMetadata(string $key): bool {
+		return isset($this->metaData[$key]);
+	}
+
+	public function getMetadata(string $key): FileMetadata {
+		return $this->metaData[$key];
 	}
 }

--- a/lib/Album/AlbumFile.php
+++ b/lib/Album/AlbumFile.php
@@ -32,6 +32,7 @@ class AlbumFile {
 	private int $size;
 	private int $mtime;
 	private string $etag;
+	private int $added;
 	/** @var array<int, FileMetadata> */
 	private array $metaData = [];
 
@@ -41,7 +42,8 @@ class AlbumFile {
 		string $mimeType,
 		int $size,
 		int $mtime,
-		string $etag
+		string $etag,
+		int $added
 	) {
 		$this->fileId = $fileId;
 		$this->name = $name;
@@ -49,6 +51,7 @@ class AlbumFile {
 		$this->size = $size;
 		$this->mtime = $mtime;
 		$this->etag = $etag;
+		$this->added = $added;
 	}
 
 	public function getFileId(): int {
@@ -85,5 +88,9 @@ class AlbumFile {
 
 	public function getMetadata(string $key): FileMetadata {
 		return $this->metaData[$key];
+	}
+
+	public function getAdded(): int {
+		return $this->added;
 	}
 }

--- a/lib/Album/AlbumInfo.php
+++ b/lib/Album/AlbumInfo.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Album;
+
+class AlbumInfo {
+	private int $id;
+	private string $userId;
+	private string $title;
+
+	public function __construct(int $id, string $userId, string $title) {
+		$this->id = $id;
+		$this->userId = $userId;
+		$this->title = $title;
+	}
+
+	public function getId(): int {
+		return $this->id;
+	}
+
+	public function getUserId(): string {
+		return $this->userId;
+	}
+
+	public function getTitle(): string {
+		return $this->title;
+	}
+}

--- a/lib/Album/AlbumInfo.php
+++ b/lib/Album/AlbumInfo.php
@@ -27,11 +27,24 @@ class AlbumInfo {
 	private int $id;
 	private string $userId;
 	private string $title;
+	private string $location;
+	private int $created;
+	private int $lastAdded;
 
-	public function __construct(int $id, string $userId, string $title) {
+	public function __construct(
+		int $id,
+		string $userId,
+		string $title,
+		string $location,
+		int $created,
+		int $lastAdded
+	) {
 		$this->id = $id;
 		$this->userId = $userId;
 		$this->title = $title;
+		$this->location = $location;
+		$this->created = $created;
+		$this->lastAdded = $lastAdded;
 	}
 
 	public function getId(): int {
@@ -44,5 +57,17 @@ class AlbumInfo {
 
 	public function getTitle(): string {
 		return $this->title;
+	}
+
+	public function getLocation(): string {
+		return $this->location;
+	}
+
+	public function getCreated(): int {
+		return $this->created;
+	}
+
+	public function getLastAddedPhoto(): int {
+		return $this->lastAdded;
 	}
 }

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Album;
+
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\IMimeTypeLoader;
+use OCP\IDBConnection;
+
+class AlbumMapper {
+	private IDBConnection $connection;
+	private IMimeTypeLoader $mimeTypeLoader;
+
+	public function __construct(IDBConnection $connection, IMimeTypeLoader $mimeTypeLoader) {
+		$this->connection = $connection;
+		$this->mimeTypeLoader = $mimeTypeLoader;
+	}
+
+	public function create(string $userId, string $name): AlbumInfo {
+		$query = $this->connection->getQueryBuilder();
+		$query->insert("photos_albums")
+			->values([
+				'user' => $query->createNamedParameter($userId),
+				'name' => $query->createNamedParameter($name),
+			]);
+		$query->executeStatement();
+		$id = $query->getLastInsertId();
+
+		return new AlbumInfo($id, $userId, $name);
+	}
+
+	public function get(int $id): ?AlbumInfo {
+		$query = $this->connection->getQueryBuilder();
+		$query->select("name", "user")
+			->from("photos_albums")
+			->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		$row = $query->executeQuery()->fetch();
+		if ($row) {
+			return new AlbumInfo($id, $row['user'], $row['name']);
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * @param string $userId
+	 * @return AlbumInfo[]
+	 */
+	public function getForUser(string $userId): array {
+		$query = $this->connection->getQueryBuilder();
+		$query->select("album_id", "name")
+			->from("photos_albums")
+			->where($query->expr()->eq('user', $query->createNamedParameter($userId)));
+		$rows = $query->executeQuery()->fetchAll();
+		return array_map(function (array $row) use ($userId) {
+			return new AlbumInfo($row['album_id'], $userId, $row['name']);
+		}, $rows);
+	}
+
+	public function rename(int $id, string $newName): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->update("photos_albums")
+			->set("name", $query->createNamedParameter($newName))
+			->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		$query->executeStatement();
+	}
+
+	public function delete(int $id): void {
+		$this->connection->beginTransaction();
+		$query = $this->connection->getQueryBuilder();
+		$query->delete("photos_albums")
+			->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		$query->executeStatement();
+
+
+		$query = $this->connection->getQueryBuilder();
+		$query->delete("photos_albums_files")
+			->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+		$query->executeStatement();
+		$this->connection->commit();
+	}
+
+	/**
+	 * @param string $userId
+	 * @return AlbumWithFiles[]
+	 */
+	public function getForUserWithFiles(string $userId): array {
+		$query = $this->connection->getQueryBuilder();
+		$query->select("fileid", "mimetype", "a.album_id")
+			->selectAlias("f.name", "file_name")
+			->selectAlias("a.name", "album_name")
+			->from("photos_albums", "a")
+			->leftJoin("a", "photos_albums_files", "p", $query->expr()->eq("a.album_id", "p.album_id"))
+			->leftJoin("p", "filecache", "f", $query->expr()->eq("p.file_id", "f.fileid"))
+			->where($query->expr()->eq('user', $query->createNamedParameter($userId)));
+		$rows = $query->executeQuery()->fetchAll();
+
+		$filesByAlbum = [];
+		$albumsById = [];
+		foreach ($rows as $row) {
+			$albumId = $row['album_id'];
+			if ($row['fileid']) {
+				$mimeId = $row['mimetype'];
+				$mimeType = $this->mimeTypeLoader->getMimetypeById($mimeId);
+				$filesByAlbum[$albumId][] = new AlbumFile($row['fileid'], $row['file_name'], $mimeType);
+			}
+
+			if (!isset($albumsById[$albumId])) {
+				$albumsById[$albumId] = new AlbumInfo($albumId, $userId, $row['album_name']);
+			}
+		}
+
+		$result = [];
+		foreach ($albumsById as $id => $album) {
+			$result[] = new AlbumWithFiles($album, $filesByAlbum[$id] ?? []);
+		}
+		return $result;
+	}
+
+	public function addFile(int $albumId, int $fileId): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->insert("photos_albums_files")
+			->values([
+				"album_id" => $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT),
+				"file_id" => $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)
+			]);
+		$query->executeStatement();
+	}
+
+	public function removeFile(int $albumId, int $fileId): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->delete("photos_albums_files")
+			->where($query->expr()->eq("album_id", $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq("file_id", $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+		$query->executeStatement();
+	}
+}

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -106,7 +106,7 @@ class AlbumMapper {
 	 */
 	public function getForUserWithFiles(string $userId): array {
 		$query = $this->connection->getQueryBuilder();
-		$query->select("fileid", "mimetype", "a.album_id")
+		$query->select("fileid", "mimetype", "a.album_id", "size", "mtime", "etag")
 			->selectAlias("f.name", "file_name")
 			->selectAlias("a.name", "album_name")
 			->from("photos_albums", "a")
@@ -122,7 +122,7 @@ class AlbumMapper {
 			if ($row['fileid']) {
 				$mimeId = $row['mimetype'];
 				$mimeType = $this->mimeTypeLoader->getMimetypeById($mimeId);
-				$filesByAlbum[$albumId][] = new AlbumFile($row['fileid'], $row['file_name'], $mimeType);
+				$filesByAlbum[$albumId][] = new AlbumFile($row['fileid'], $row['file_name'], $mimeType, $row['size'], $row['mtime'], $row['etag']);
 			}
 
 			if (!isset($albumsById[$albumId])) {

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -75,7 +75,7 @@ class AlbumMapper {
 			->where($query->expr()->eq('user', $query->createNamedParameter($userId)));
 		$rows = $query->executeQuery()->fetchAll();
 		return array_map(function (array $row) use ($userId) {
-			return new AlbumInfo($row['album_id'], $userId, $row['name']);
+			return new AlbumInfo((int)$row['album_id'], $userId, $row['name']);
 		}, $rows);
 	}
 
@@ -120,11 +120,11 @@ class AlbumMapper {
 		$filesByAlbum = [];
 		$albumsById = [];
 		foreach ($rows as $row) {
-			$albumId = $row['album_id'];
+			$albumId = (int)$row['album_id'];
 			if ($row['fileid']) {
 				$mimeId = $row['mimetype'];
 				$mimeType = $this->mimeTypeLoader->getMimetypeById($mimeId);
-				$filesByAlbum[$albumId][] = new AlbumFile($row['fileid'], $row['file_name'], $mimeType, $row['size'], $row['mtime'], $row['etag']);
+				$filesByAlbum[$albumId][] = new AlbumFile((int)$row['fileid'], $row['file_name'], $mimeType, (int)$row['size'], (int)$row['mtime'], $row['etag']);
 			}
 
 			if (!isset($albumsById[$albumId])) {

--- a/lib/Album/AlbumWithFiles.php
+++ b/lib/Album/AlbumWithFiles.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Album;
+
+use OC\Files\Cache\CacheEntry;
+
+class AlbumWithFiles {
+	private AlbumInfo $info;
+	/** @var CacheEntry[] */
+	private array $files;
+
+	public function __construct(AlbumInfo $info, array $files) {
+		$this->info = $info;
+		$this->files = $files;
+	}
+
+	public function getAlbum(): AlbumInfo {
+		return $this->info;
+	}
+
+	/**
+	 * @return CacheEntry[]
+	 */
+	public function getFiles(): array {
+		return $this->files;
+	}
+}

--- a/lib/Album/AlbumWithFiles.php
+++ b/lib/Album/AlbumWithFiles.php
@@ -27,7 +27,7 @@ use OC\Files\Cache\CacheEntry;
 
 class AlbumWithFiles {
 	private AlbumInfo $info;
-	/** @var CacheEntry[] */
+	/** @var AlbumFile[] */
 	private array $files;
 
 	public function __construct(AlbumInfo $info, array $files) {
@@ -40,9 +40,18 @@ class AlbumWithFiles {
 	}
 
 	/**
-	 * @return CacheEntry[]
+	 * @return AlbumFile[]
 	 */
 	public function getFiles(): array {
 		return $this->files;
+	}
+
+	/**
+	 * @return int[]
+	 */
+	public function getFileIds(): array {
+		return array_map(function(AlbumFile $file) {
+			return $file->getFileId();
+		}, $this->files);
 	}
 }

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace OCA\Photos\AppInfo;
 
+use OCA\DAV\Connector\Sabre\Principal;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
@@ -58,6 +59,8 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function register(IRegistrationContext $context): void {
+		/** Register $principalBackend for the DAV collection */
+		$context->registerServiceAlias('principalBackend', Principal::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Exception/AlreadyInAlbumException.php
+++ b/lib/Exception/AlreadyInAlbumException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Exception;
+
+class AlreadyInAlbumException extends \Exception {
+
+}

--- a/lib/Migration/Version20000Date20220727125801.php
+++ b/lib/Migration/Version20000Date20220727125801.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Your name <your@email.com>
+ *
+ * @author Your name <your@email.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Migration;
+
+use Closure;
+use Doctrine\DBAL\Types\Types;
+use OC\DB\SchemaWrapper;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20000Date20220727125801 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var SchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if (!$schema->hasTable("photos_albums")) {
+			$table = $schema->createTable("photos_albums");
+			$table->addColumn('album_id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('name', 'string', [
+				'notnull' => true,
+				'length' => 255,
+			]);
+			$table->addColumn('user', 'string', [
+				'notnull' => true,
+				'length' => 255,
+			]);
+			$table->setPrimaryKey(['album_id']);
+			$table->addIndex(['user'], 'pa_user');
+		}
+
+		if (!$schema->hasTable('photos_albums_files')) {
+			$table = $schema->createTable('photos_albums_files');
+			$table->addColumn('album_file_id', Types::BIGINT, [
+				'autoincrement' => true,
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('album_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->addColumn('file_id', Types::BIGINT, [
+				'notnull' => true,
+				'length' => 20,
+			]);
+			$table->setPrimaryKey(['album_file_id']);
+			$table->addIndex(['album_id'], 'paf_folder');
+			$table->addUniqueIndex(['album_id', 'file_id'], 'paf_album_file');
+		}
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version20000Date20220727125801.php
+++ b/lib/Migration/Version20000Date20220727125801.php
@@ -1,11 +1,8 @@
 <?php
 
 declare(strict_types=1);
-
 /**
- * @copyright Copyright (c) 2022 Your name <your@email.com>
- *
- * @author Your name <your@email.com>
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -16,11 +13,11 @@ declare(strict_types=1);
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Affero General Public License for more details.
  *
  * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
 

--- a/lib/Migration/Version20000Date20220727125801.php
+++ b/lib/Migration/Version20000Date20220727125801.php
@@ -53,6 +53,16 @@ class Version20000Date20220727125801 extends SimpleMigrationStep {
 				'notnull' => true,
 				'length' => 255,
 			]);
+			$table->addColumn('created', 'bigint', [
+				'notnull' => true,
+			]);
+			$table->addColumn('location', 'string', [
+				'notnull' => true,
+				'length' => 255,
+			]);
+			$table->addColumn('last_added_photo', 'bigint', [
+				'notnull' => true,
+			]);
 			$table->setPrimaryKey(['album_id']);
 			$table->addIndex(['user'], 'pa_user');
 		}
@@ -71,6 +81,9 @@ class Version20000Date20220727125801 extends SimpleMigrationStep {
 			$table->addColumn('file_id', Types::BIGINT, [
 				'notnull' => true,
 				'length' => 20,
+			]);
+			$table->addColumn('added', 'bigint', [
+				'notnull' => true,
 			]);
 			$table->setPrimaryKey(['album_file_id']);
 			$table->addIndex(['album_id'], 'paf_folder');

--- a/lib/Sabre/Album/AlbumPhoto.php
+++ b/lib/Sabre/Album/AlbumPhoto.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Sabre\Album;
+
+use OCA\Photos\Album\AlbumFile;
+use OCA\Photos\Album\AlbumInfo;
+use OCA\Photos\Album\AlbumMapper;
+use OCP\Files\Folder;
+use OCP\Files\Node;
+use OCP\Files\File;
+use OCP\Files\NotFoundException;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\IFile;
+
+class AlbumPhoto implements IFile {
+	private AlbumMapper $albumMapper;
+	private AlbumInfo $album;
+	private AlbumFile $file;
+	private Folder $userFolder;
+
+	public function __construct(AlbumMapper $albumMapper, AlbumInfo $album, AlbumFile $file, Folder $userFolder) {
+		$this->albumMapper = $albumMapper;
+		$this->album = $album;
+		$this->file = $file;
+		$this->userFolder = $userFolder;
+	}
+
+	public function delete() {
+		$this->albumMapper->removeFile($this->album->getId(), $this->file->getFileId());
+	}
+
+	public function getName() {
+		return $this->file->getName();
+	}
+
+	public function setName($name) {
+		throw new Forbidden('Can\'t rename photos trough the album api');
+	}
+
+	public function getLastModified() {
+		return $this->file->getMTime();
+	}
+
+	public function put($data) {
+		throw new Forbidden('Can\'t write to photos trough the album api');
+	}
+
+	public function get() {
+		$nodes = $this->userFolder->getById($this->file->getFileId());
+		$node = current($nodes);
+		if ($node) {
+			/** @var Node $node */
+			if ($node instanceof File) {
+				return $node->fopen('r');
+			} else {
+				throw new NotFoundException("Photo is a folder");
+			}
+		} else {
+			throw new NotFoundException("Photo not found for user");
+		}
+	}
+
+	public function getContentType() {
+		return $this->file->getMimeType();
+	}
+
+	public function getETag() {
+		return $this->file->getEtag();
+	}
+
+	public function getSize() {
+		return $this->file->getSize();
+	}
+}

--- a/lib/Sabre/Album/AlbumPhoto.php
+++ b/lib/Sabre/Album/AlbumPhoto.php
@@ -51,7 +51,7 @@ class AlbumPhoto implements IFile {
 	}
 
 	public function getName() {
-		return $this->file->getName();
+		return $this->file->getFileId() . "-" . $this->file->getName();
 	}
 
 	public function setName($name) {
@@ -91,5 +91,9 @@ class AlbumPhoto implements IFile {
 
 	public function getSize() {
 		return $this->file->getSize();
+	}
+
+	public function getFile(): AlbumFile {
+		return $this->file;
 	}
 }

--- a/lib/Sabre/Album/AlbumPhoto.php
+++ b/lib/Sabre/Album/AlbumPhoto.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/lib/Sabre/Album/AlbumRoot.php
+++ b/lib/Sabre/Album/AlbumRoot.php
@@ -80,7 +80,7 @@ class AlbumRoot implements ICollection, ICopyTarget {
 
 	public function getChild($name): AlbumPhoto {
 		foreach ($this->album->getFiles() as $file) {
-			if ($file->getName() === $name) {
+			if ($file->getFileId() . "-" . $file->getName() === $name) {
 				return new AlbumPhoto($this->albumMapper, $this->album->getAlbum(), $file, $this->userFolder);
 			}
 		}

--- a/lib/Sabre/Album/AlbumRoot.php
+++ b/lib/Sabre/Album/AlbumRoot.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Sabre\Album;
+
+use OCA\DAV\Connector\Sabre\File;
+use OCA\Photos\Album\AlbumFile;
+use OCA\Photos\Album\AlbumMapper;
+use OCA\Photos\Album\AlbumWithFiles;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use Sabre\DAV\Exception\Conflict;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+use Sabre\DAV\ICopyTarget;
+use Sabre\DAV\INode;
+
+class AlbumRoot implements ICollection, ICopyTarget {
+	private AlbumMapper $albumMapper;
+	private AlbumWithFiles $album;
+	private IRootFolder $rootFolder;
+	private Folder $userFolder;
+	private IUser $user;
+
+	public function __construct(AlbumMapper $albumMapper, AlbumWithFiles $album, IRootFolder $rootFolder, Folder $userFolder, IUser $user) {
+		$this->albumMapper = $albumMapper;
+		$this->album = $album;
+		$this->rootFolder = $rootFolder;
+		$this->userFolder = $userFolder;
+		$this->user = $user;
+	}
+
+	public function delete() {
+		$this->albumMapper->delete($this->album->getAlbum()->getId());
+	}
+
+	public function getName(): string {
+		return basename($this->album->getAlbum()->getTitle());
+	}
+
+	public function setName($name) {
+		$this->albumMapper->rename($this->album->getAlbum()->getId(), $name);
+	}
+
+	public function createFile($name, $data = null) {
+		throw new Forbidden('Not allowed to create files in this folder, copy files into this folder instead');
+	}
+
+	public function createDirectory($name) {
+		throw new Forbidden('Not allowed to create directories in this folder');
+	}
+
+	public function getChildren(): array {
+		return array_map(function (AlbumFile $file) {
+			return new AlbumPhoto($this->albumMapper, $this->album->getAlbum(), $file, $this->userFolder);
+		}, $this->album->getFiles());
+	}
+
+	public function getChild($name): AlbumPhoto {
+		foreach ($this->album->getFiles() as $file) {
+			if ($file->getName() === $name) {
+				return new AlbumPhoto($this->albumMapper, $this->album->getAlbum(), $file, $this->userFolder);
+			}
+		}
+		throw new NotFound("$name not found");
+	}
+
+	public function childExists($name): bool {
+		try {
+			$this->getChild($name);
+			return true;
+		} catch (NotFound $e) {
+			return false;
+		}
+	}
+
+	public function getLastModified(): int {
+		return 0;
+	}
+
+	public function copyInto($targetName, $sourcePath, INode $sourceNode): bool {
+		$uid = $this->user->getUID();
+		if ($sourceNode instanceof File) {
+			$sourceId = $sourceNode->getId();
+			if (in_array($sourceId, $this->album->getFileIds())) {
+				throw new Conflict("File $sourceId is already in the folder");
+			}
+			if ($sourceNode->getFileInfo()->getOwner()->getUID() === $uid) {
+				$this->albumMapper->addFile($this->album->getAlbum()->getId(), $sourceId);
+				return true;
+			}
+		}
+		throw new \Exception("Can't add file to album, only files from $uid can be added");
+	}
+}

--- a/lib/Sabre/Album/AlbumRoot.php
+++ b/lib/Sabre/Album/AlbumRoot.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
  *
  * @license GNU AGPL version 3 or any later version
  *

--- a/lib/Sabre/Album/AlbumRoot.php
+++ b/lib/Sabre/Album/AlbumRoot.php
@@ -114,4 +114,8 @@ class AlbumRoot implements ICollection, ICopyTarget {
 		}
 		throw new \Exception("Can't add file to album, only files from $uid can be added");
 	}
+
+	public function getAlbum(): AlbumWithFiles {
+		return $this->album;
+	}
 }

--- a/lib/Sabre/Album/AlbumsHome.php
+++ b/lib/Sabre/Album/AlbumsHome.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Photos\Sabre\Album;
+
+use OCA\Photos\Album\AlbumMapper;
+use OCA\Photos\Album\AlbumWithFiles;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+
+class AlbumsHome implements ICollection {
+	private AlbumMapper $albumMapper;
+	private array $principalInfo;
+	private IUser $user;
+	private IRootFolder $rootFolder;
+	private Folder $userFolder;
+
+	public function __construct(
+		array $principalInfo,
+		AlbumMapper $albumMapper,
+		IUser $user,
+		IRootFolder $rootFolder
+	) {
+		$this->principalInfo = $principalInfo;
+		$this->albumMapper = $albumMapper;
+		$this->user = $user;
+		$this->rootFolder = $rootFolder;
+		$this->userFolder = $rootFolder->getUserFolder($user->getUID());
+	}
+
+	public function delete() {
+		throw new Forbidden();
+	}
+
+	public function getName(): string {
+		return 'albums';
+	}
+
+	public function setName($name) {
+		throw new Forbidden('Permission denied to rename this folder');
+	}
+
+	public function createFile($name, $data = null) {
+		throw new Forbidden('Not allowed to create files in this folder');
+	}
+
+	public function createDirectory($name) {
+		$uid = $this->user->getUID();
+		$this->albumMapper->create($uid, $name);
+	}
+
+	public function getChild($name) {
+		foreach ($this->getChildren() as $child) {
+			if ($child->getName() === $name) {
+				return $child;
+			}
+		}
+
+		throw new NotFound();
+	}
+
+	/**
+	 * @return AlbumRoot[]
+	 */
+	public function getChildren(): array {
+		$folders = $this->albumMapper->getForUserWithFiles($this->user->getUID());
+		return array_map(function (AlbumWithFiles $folder) {
+			return new AlbumRoot($this->albumMapper, $folder, $this->rootFolder, $this->userFolder, $this->user);
+		}, $folders);
+	}
+
+	public function childExists($name): bool {
+		try {
+			$this->getChild($name);
+			return true;
+		} catch (NotFound $e) {
+			return false;
+		}
+	}
+
+	public function getLastModified(): int {
+		return 0;
+	}
+}

--- a/lib/Sabre/Album/AlbumsHome.php
+++ b/lib/Sabre/Album/AlbumsHome.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -20,6 +20,7 @@ declare(strict_types=1);
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCA\Photos\Sabre\Album;
 
 use OCA\Photos\Album\AlbumMapper;

--- a/lib/Sabre/Album/PropFindPlugin.php
+++ b/lib/Sabre/Album/PropFindPlugin.php
@@ -21,35 +21,30 @@ declare(strict_types=1);
  *
  */
 
-namespace OCA\Photos\Album;
+namespace OCA\Photos\Sabre\Album;
 
-class AlbumWithFiles {
-	private AlbumInfo $info;
-	/** @var AlbumFile[] */
-	private array $files;
+use Sabre\DAV\INode;
+use Sabre\DAV\PropFind;
+use Sabre\DAV\Server;
+use Sabre\DAV\ServerPlugin;
 
-	public function __construct(AlbumInfo $info, array $files) {
-		$this->info = $info;
-		$this->files = $files;
+class PropFindPlugin extends ServerPlugin {
+	private Server $server;
+
+	public function initialize(Server $server) {
+		$this->server = $server;
+
+		$this->server->on('propFind', [$this, 'propFind']);
 	}
 
-	public function getAlbum(): AlbumInfo {
-		return $this->info;
-	}
 
-	/**
-	 * @return AlbumFile[]
-	 */
-	public function getFiles(): array {
-		return $this->files;
-	}
+	public function propFind(PropFind $propFind, INode $node) {
+		if (!($node instanceof AlbumPhoto)) {
+			return;
+		}
 
-	/**
-	 * @return int[]
-	 */
-	public function getFileIds(): array {
-		return array_map(function(AlbumFile $file) {
-			return $file->getFileId();
-		}, $this->files);
+		$propFind->handle('{http://nextcloud.org/ns}file-name', function () use ($node) {
+			return $node->getFile()->getName();
+		});
 	}
 }

--- a/lib/Sabre/Album/PropFindPlugin.php
+++ b/lib/Sabre/Album/PropFindPlugin.php
@@ -23,28 +23,72 @@ declare(strict_types=1);
 
 namespace OCA\Photos\Sabre\Album;
 
+use OC\Metadata\IMetadataManager;
+use OCA\DAV\Connector\Sabre\FilesPlugin;
+use OCP\IConfig;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
 use Sabre\DAV\Server;
 use Sabre\DAV\ServerPlugin;
 
 class PropFindPlugin extends ServerPlugin {
-	private Server $server;
+	private IConfig $config;
+	private IMetadataManager $metadataManager;
+	private bool $metadataEnabled;
 
-	public function initialize(Server $server) {
-		$this->server = $server;
-
-		$this->server->on('propFind', [$this, 'propFind']);
+	public function __construct(IConfig $config, IMetadataManager $metadataManager) {
+		$this->config = $config;
+		$this->metadataManager = $metadataManager;
+		$this->metadataEnabled = $this->config->getSystemValueBool('enable_file_metadata', true);
 	}
 
 
+	public function initialize(Server $server) {
+		$server->on('propFind', [$this, 'propFind']);
+	}
+
 	public function propFind(PropFind $propFind, INode $node) {
-		if (!($node instanceof AlbumPhoto)) {
-			return;
+		if ($node instanceof AlbumPhoto) {
+			$propFind->handle('{http://nextcloud.org/ns}file-name', function () use ($node) {
+				return $node->getFile()->getName();
+			});
+			$propFind->handle(FilesPlugin::INTERNAL_FILEID_PROPERTYNAME, function () use ($node) {
+				return $node->getFile()->getFileId();
+			});
+			$propFind->handle(FilesPlugin::GETETAG_PROPERTYNAME, function () use ($node): string {
+				return $node->getETag();
+			});
+
+			if ($this->metadataEnabled) {
+				$propFind->handle(FilesPlugin::FILE_METADATA_SIZE, function () use ($node) {
+					if (!str_starts_with($node->getFile()->getMimetype(), 'image')) {
+						return json_encode((object)[]);
+					}
+
+					if ($node->getFile()->hasMetadata('size')) {
+						$sizeMetadata = $node->getFile()->getMetadata('size');
+					} else {
+						$sizeMetadata = $this->metadataManager->fetchMetadataFor('size', [$node->getFile()->getFileId()])[$node->getFile()->getFileId()];
+					}
+
+					return json_encode((object)$sizeMetadata->getMetadata());
+				});
+			}
 		}
 
-		$propFind->handle('{http://nextcloud.org/ns}file-name', function () use ($node) {
-			return $node->getFile()->getName();
-		});
+		if ($node instanceof AlbumRoot) {
+			// TODO detect dynamically which metadata groups are requested and
+			// preload all of them and not just size
+			if ($this->metadataEnabled && in_array(FilesPlugin::FILE_METADATA_SIZE, $propFind->getRequestedProperties(), true)) {
+				$fileIds = $node->getAlbum()->getFileIds();
+
+				$preloadedMetadata = $this->metadataManager->fetchMetadataFor('size', $fileIds);
+				foreach ($node->getAlbum()->getFiles() as $file) {
+					if (str_starts_with($file->getMimeType(), 'image')) {
+						$file->setMetadata('size', $preloadedMetadata[$file->getFileId()]);
+					}
+				}
+			}
+		}
 	}
 }

--- a/lib/Sabre/PhotosHome.php
+++ b/lib/Sabre/PhotosHome.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -20,6 +20,7 @@ declare(strict_types=1);
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCA\Photos\Sabre;
 
 use OCA\Photos\Album\AlbumMapper;

--- a/lib/Sabre/PhotosHome.php
+++ b/lib/Sabre/PhotosHome.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Photos\Sabre;
+
+use OCA\Photos\Album\AlbumMapper;
+use OCA\Photos\Sabre\Album\AlbumsHome;
+use OCP\Files\Folder;
+use OCP\Files\IRootFolder;
+use OCP\IUser;
+use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
+use Sabre\DAV\ICollection;
+
+class PhotosHome implements ICollection {
+	private AlbumMapper $albumMapper;
+	private array $principalInfo;
+	private IUser $user;
+	private IRootFolder $rootFolder;
+	private Folder $userFolder;
+
+	public function __construct(
+		array $principalInfo,
+		AlbumMapper $albumMapper,
+		IUser $user,
+		IRootFolder $rootFolder
+	) {
+		$this->principalInfo = $principalInfo;
+		$this->albumMapper = $albumMapper;
+		$this->user = $user;
+		$this->rootFolder = $rootFolder;
+		$this->userFolder = $rootFolder->getUserFolder($user->getUID());
+	}
+
+	public function delete() {
+		throw new Forbidden();
+	}
+
+	public function getName(): string {
+		[, $name] = \Sabre\Uri\split($this->principalInfo['uri']);
+		return $name;
+	}
+
+	public function setName($name) {
+		throw new Forbidden('Permission denied to rename this folder');
+	}
+
+	public function createFile($name, $data = null) {
+		throw new Forbidden('Not allowed to create files in this folder');
+	}
+
+	public function createDirectory($name) {
+		throw new Forbidden('Permission denied to create folders in this folder');
+	}
+
+	public function getChild($name) {
+		if ($name === 'albums') {
+			return new AlbumsHome($this->principalInfo, $this->albumMapper, $this->user, $this->rootFolder);
+		}
+
+		throw new NotFound();
+	}
+
+	/**
+	 * @return AlbumsHome[]
+	 */
+	public function getChildren(): array {
+		return [new AlbumsHome($this->principalInfo, $this->albumMapper, $this->user, $this->rootFolder)];
+	}
+
+	public function childExists($name): bool {
+		return $name === 'albums';
+	}
+
+	public function getLastModified(): int {
+		return 0;
+	}
+}

--- a/lib/Sabre/RootCollection.php
+++ b/lib/Sabre/RootCollection.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
  *
  * @license GNU AGPL version 3 or any later version
  *
@@ -20,6 +20,7 @@ declare(strict_types=1);
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
 namespace OCA\Photos\Sabre;
 
 use OCA\Photos\Album\AlbumMapper;

--- a/lib/Sabre/RootCollection.php
+++ b/lib/Sabre/RootCollection.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Photos\Sabre;
+
+use OCA\Photos\Album\AlbumMapper;
+use OCP\Files\IRootFolder;
+use OCP\IUserSession;
+use Sabre\DAV\INode;
+use Sabre\DAVACL\AbstractPrincipalCollection;
+use Sabre\DAVACL\PrincipalBackend;
+
+class RootCollection extends AbstractPrincipalCollection {
+	private AlbumMapper $folderMapper;
+	private IUserSession $userSession;
+	private IRootFolder $rootFolder;
+
+	public function __construct(
+		AlbumMapper $folderMapper,
+		IUserSession $userSession,
+		IRootFolder $rootFolder,
+		PrincipalBackend\BackendInterface $principalBackend
+	) {
+		parent::__construct($principalBackend, 'principals/users');
+
+		$this->folderMapper = $folderMapper;
+		$this->userSession = $userSession;
+		$this->rootFolder = $rootFolder;
+	}
+
+	/**
+	 * This method returns a node for a principal.
+	 *
+	 * The passed array contains principal information, and is guaranteed to
+	 * at least contain a uri item. Other properties may or may not be
+	 * supplied by the authentication backend.
+	 *
+	 * @param array $principalInfo
+	 * @return INode
+	 */
+	public function getChildForPrincipal(array $principalInfo): PhotosHome {
+		[, $name] = \Sabre\Uri\split($principalInfo['uri']);
+		$user = $this->userSession->getUser();
+		if (is_null($user) || $name !== $user->getUID()) {
+			throw new \Sabre\DAV\Exception\Forbidden();
+		}
+		return new PhotosHome($principalInfo, $this->folderMapper, $user, $this->rootFolder);
+	}
+
+	public function getName(): string {
+		return 'photos';
+	}
+}

--- a/tests/Album/AlbumMapperTest.php
+++ b/tests/Album/AlbumMapperTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Tests\Album;
+
+use OCA\Photos\Album\AlbumFile;
+use OCA\Photos\Album\AlbumInfo;
+use OCA\Photos\Album\AlbumMapper;
+use OCA\Photos\Album\AlbumWithFiles;
+use OCP\Constants;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Files\IMimeTypeLoader;
+use OCP\IDBConnection;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class AlbumMapperTest extends TestCase {
+	/** @var IDBConnection */
+	private $connection;
+	private array $createdFiles = [];
+	/** @var IMimeTypeLoader */
+	private $mimeLoader;
+	/** @var AlbumMapper */
+	private $mapper;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->createdFiles = [];
+		$this->connection = \OC::$server->get(IDBConnection::class);
+		$this->mimeLoader = \OC::$server->get(IMimeTypeLoader::class);
+		$this->mapper = new AlbumMapper($this->connection, $this->mimeLoader);
+	}
+
+	protected function tearDown():void {
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('filecache')
+			->where($query->expr()->eq('fileid', $query->createParameter("fileid")));
+		foreach ($this->createdFiles as $createdFile) {
+			$query->setParameter("fileid", $createdFile);
+			$query->executeStatement();
+		}
+		$this->createdFiles = [];
+
+		$this->connection->getQueryBuilder()->delete('photos_albums')->executeStatement();
+		$this->connection->getQueryBuilder()->delete('photos_albums_files')->executeStatement();
+
+		parent::tearDown();
+	}
+
+	private function createFile(string $name, string $mimeType, int $size = 10, int $mtime = 10000, int $permissions = Constants::PERMISSION_ALL): int {
+		$mimeId = $this->mimeLoader->getId($mimeType);
+		$mimePartId = $this->mimeLoader->getId(substr($mimeType, strpos($mimeType, '/')));
+		$query = $this->connection->getQueryBuilder();
+		$query->insert('filecache')
+			->values([
+				'storage' => $query->createNamedParameter(-1, IQueryBuilder::PARAM_INT),
+				'parent' => $query->createNamedParameter(-1, IQueryBuilder::PARAM_INT),
+				'path' => $query->createNamedParameter("/dummy/" . $name),
+				'path_hash' => $query->createNamedParameter(md5("dummy/" . $name)),
+				'name' => $query->createNamedParameter($name),
+				'mimetype' => $query->createNamedParameter($mimeId, IQueryBuilder::PARAM_INT),
+				'mimepart' => $query->createNamedParameter($mimePartId, IQueryBuilder::PARAM_INT),
+				'size' => $query->createNamedParameter($size, IQueryBuilder::PARAM_INT),
+				'mtime' => $query->createNamedParameter($mtime, IQueryBuilder::PARAM_INT),
+				'storage_mtime' => $query->createNamedParameter($mtime, IQueryBuilder::PARAM_INT),
+				'permissions' => $query->createNamedParameter($permissions, IQueryBuilder::PARAM_INT),
+				'etag' => $query->createNamedParameter('dummy'),
+			]);
+		$query->executeStatement();
+		$id = $query->getLastInsertId();
+		$this->createdFiles[] = $id;
+		return $id;
+	}
+
+	public function testCreateGet() {
+		$album = $this->mapper->create("user1", "album1");
+
+		$retrievedAlbum = $this->mapper->get($album->getId());
+		$this->assertEquals($album, $retrievedAlbum);
+	}
+
+	public function testCreateList() {
+		$album1 = $this->mapper->create("user1", "album1");
+		$album2 = $this->mapper->create("user1", "album2");
+		$this->mapper->create("user2", "album3");
+
+		$retrievedAlbums = $this->mapper->getForUser('user1');
+		usort($retrievedAlbums, function(AlbumInfo $a, AlbumInfo $b) {
+			return $a->getId() <=> $b->getId();
+		});
+		$this->assertEquals([$album1, $album2], $retrievedAlbums);
+	}
+
+	public function testCreateDeleteGet() {
+		$album = $this->mapper->create("user1", "album1");
+
+		$retrievedAlbum = $this->mapper->get($album->getId());
+		$this->assertEquals($album, $retrievedAlbum);
+
+		$this->mapper->delete($album->getId());
+
+		$this->assertEquals(null, $this->mapper->get($album->getId()));
+	}
+
+	public function testCreateDeleteList() {
+		$album1 = $this->mapper->create("user1", "album1");
+		$album2 = $this->mapper->create("user1", "album2");
+		$this->mapper->create("user2", "album3");
+
+		$this->mapper->delete($album1->getId());
+
+		$retrievedAlbums = $this->mapper->getForUser('user1');
+		usort($retrievedAlbums, function(AlbumInfo $a, AlbumInfo $b) {
+			return $a->getId() <=> $b->getId();
+		});
+		$this->assertEquals([$album2], $retrievedAlbums);
+	}
+
+	public function testCreateRenameGet() {
+		$album = $this->mapper->create("user1", "album1");
+		$this->mapper->rename($album->getId(),"renamed");
+
+		$retrievedAlbum = $this->mapper->get($album->getId());
+		$this->assertEquals("renamed", $retrievedAlbum->getTitle());
+	}
+
+	public function testEmptyFiles() {
+		$album1 = $this->mapper->create("user1", "album1");
+
+		$this->assertEquals([new AlbumWithFiles($album1, [])], $this->mapper->getForUserWithFiles("user1"));
+	}
+
+	public function testAddFiles() {
+		$album1 = $this->mapper->create("user1", "album1");
+		$album2 = $this->mapper->create("user1", "album2");
+
+		$fileId1 = $this->createFile("file1", "text/plain");
+		$fileId2 = $this->createFile("file2", "image/png");
+
+		$this->mapper->addFile($album1->getId(), $fileId1);
+		$this->mapper->addFile($album1->getId(), $fileId2);
+		$this->mapper->addFile($album2->getId(), $fileId1);
+
+		$albumsWithFiles = $this->mapper->getForUserWithFiles("user1");
+		usort($albumsWithFiles, function(AlbumWithFiles $a, AlbumWithFiles $b) {
+			return $a->getAlbum()->getId() <=> $b->getAlbum()->getId();
+		});
+		$this->assertCount(2, $albumsWithFiles);
+
+		$this->assertEquals($album1, $albumsWithFiles[0]->getAlbum());
+		$files = $albumsWithFiles[0]->getFiles();
+		usort($files, function(AlbumFile $a, AlbumFile $b) {
+			return $a->getFileId() <=> $b->getFileId();
+		});
+		$this->assertCount(2, $files);
+		$this->assertEquals(new AlbumFile($fileId1, "file1", "text/plain"), $albumsWithFiles[0]->getFiles()[0]);
+		$this->assertEquals(new AlbumFile($fileId2, "file2", "image/png"), $albumsWithFiles[0]->getFiles()[1]);
+
+		$this->assertEquals($album2, $albumsWithFiles[1]->getAlbum());
+
+		$files = $albumsWithFiles[1]->getFiles();
+		usort($files, function(AlbumFile $a, AlbumFile $b) {
+			return $a->getFileId() <=> $b->getFileId();
+		});
+		$this->assertCount(1, $files);
+		$this->assertEquals(new AlbumFile($fileId1, "file1", "text/plain"), $albumsWithFiles[0]->getFiles()[0]);
+	}
+}

--- a/tests/Album/AlbumMapperTest.php
+++ b/tests/Album/AlbumMapperTest.php
@@ -176,8 +176,8 @@ class AlbumMapperTest extends TestCase {
 			return $a->getFileId() <=> $b->getFileId();
 		});
 		$this->assertCount(2, $files);
-		$this->assertEquals(new AlbumFile($fileId1, "file1", "text/plain"), $albumsWithFiles[0]->getFiles()[0]);
-		$this->assertEquals(new AlbumFile($fileId2, "file2", "image/png"), $albumsWithFiles[0]->getFiles()[1]);
+		$this->assertEquals(new AlbumFile($fileId1, "file1", "text/plain", 10, 10000, "dummy"), $albumsWithFiles[0]->getFiles()[0]);
+		$this->assertEquals(new AlbumFile($fileId2, "file2", "image/png", 10, 10000, "dummy"), $albumsWithFiles[0]->getFiles()[1]);
 
 		$this->assertEquals($album2, $albumsWithFiles[1]->getAlbum());
 
@@ -186,6 +186,6 @@ class AlbumMapperTest extends TestCase {
 			return $a->getFileId() <=> $b->getFileId();
 		});
 		$this->assertCount(1, $files);
-		$this->assertEquals(new AlbumFile($fileId1, "file1", "text/plain"), $albumsWithFiles[0]->getFiles()[0]);
+		$this->assertEquals(new AlbumFile($fileId1, "file1", "text/plain", 10, 10000, "dummy"), $albumsWithFiles[0]->getFiles()[0]);
 	}
 }


### PR DESCRIPTION
Allow creating and managing folders trough dav

- create albums with `mkcol`
  `curl -u admin:admin -X MKCOL http://172.19.0.2/remote.php/dav/photos/admin/albums/test`
- add photos using `COPY`
  `curl -u admin:admin -H 'Destination: http://172.19.0.2/remote.php/dav/photos/admin/albums/test2/2.png' -X COPY http://172.19.0.2/remote.php/dav/files/admin/background.png'`
  note that the destination name is ignored
- rename albums using `MOVE`
  `curl -u admin:admin -H 'Destination: http://172.19.0.2/remote.php/dav/photos/admin/albums/test' -X MOVE 'http://172.19.0.2`/remote.php/dav/photos/admin/albums/test2'
- list albums or albums contents with PROPFIND (you can use `depth: 2` to list all albums with content included)
- file names in albums are prefixed by fileid to avoid collisions, you can request the `{http://nextcloud.org/ns}file-name` property to get the original filename
- full file can be downloaded from the album dav endpoint, thumbnails can be retrieved from the normal preview api by fileid