### PR TITLE
Polish albums - second round

### DIFF
--- a/cypress/e2e/albums.cy.js
+++ b/cypress/e2e/albums.cy.js
@@ -99,4 +99,36 @@ describe('Manage albums', () => {
     cy.downloadSelection()
     cy.unselectMedia([1, 2])
   })
+
+  it('Edit an album\'s name', () => {
+    cy.get('[aria-label="Open actions menu"]').click()
+    cy.contains('Edit album details').click()
+    cy.get('form [name="name"]').clear().type("New name")
+    cy.contains('Save').click()
+
+    cy.reload()
+
+    cy.contains('New name')
+
+    cy.get('[aria-label="Open actions menu"]').click()
+    cy.contains('Edit album details').click()
+    cy.get('form [name="name"]').clear().type("albums_test")
+    cy.contains('Save').click()
+  })
+
+  it('Edit an album\'s location', () => {
+    cy.get('[aria-label="Open actions menu"]').click()
+    cy.contains('Edit album details').click()
+    cy.get('form [name="location"]').clear().type("New location")
+    cy.contains('Save').click()
+
+    cy.reload()
+
+    cy.contains('New location')
+
+    cy.get('[aria-label="Open actions menu"]').click()
+    cy.contains('Edit album details').click()
+    cy.get('form [name="location"]').clear()
+    cy.contains('Save').click()
+  })
 })

--- a/cypress/e2e/shared_albums.cy.js
+++ b/cypress/e2e/shared_albums.cy.js
@@ -128,11 +128,12 @@ describe('Manage shared albums', () => {
     cy.removeSharedAlbums()
   })
 
-  xit('Remove collaborator from an album', () => {
-    cy.get('[data-test="media"]').should('have.length', 4)
+  it('Remove collaborator from an album', () => {
+    cy.get('ul.collections__list li').should('have.length', 4)
 
     cy.logout()
     cy.login(randUser, 'password')
+    cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos`)
     cy.goToAlbum('shared_album_test4')
     cy.removeCollaborators([randUser2])
     cy.logout()

--- a/cypress/e2e/shared_albums.cy.js
+++ b/cypress/e2e/shared_albums.cy.js
@@ -123,7 +123,7 @@ describe('Manage shared albums', () => {
     cy.get('[data-test="media"]').should('have.length', 0)
   })
 
-  xit('Remove shared album', () => {
+  it('Remove shared album', () => {
     cy.goToSharedAlbum('shared_album_test3')
     cy.removeSharedAlbums()
   })

--- a/cypress/e2e/shared_albums.cy.js
+++ b/cypress/e2e/shared_albums.cy.js
@@ -161,4 +161,29 @@ describe('Manage shared albums', () => {
       cy.get('ul.collections__list li').should('have.length', 3)
     })
   })
+
+  context('Two shared albums with the same name', () => {
+    before(() => {
+      cy.logout()
+      cy.login(randUser, 'password')
+      cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
+      cy.createAnAlbumFromAlbums('shared_album_test5')
+      cy.addCollaborators([randUser2])
+      cy.logout()
+
+      cy.login(randUser3, 'password')
+      cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
+      cy.createAnAlbumFromAlbums('shared_album_test5')
+      cy.addCollaborators([randUser2])
+      cy.logout()
+    })
+
+
+    it('It should display two shared albums', () => {
+      cy.get('ul.collections__list li')
+        .contains(`shared_album_test5 (${randUser})`)
+      cy.get('ul.collections__list li')
+        .contains(`shared_album_test5 (${randUser3})`)
+    })
+  })
 })

--- a/cypress/e2e/shared_albums.cy.js
+++ b/cypress/e2e/shared_albums.cy.js
@@ -20,8 +20,10 @@
  *
  */
 import { randHash } from '../utils'
+
 const randUser = randHash()
 const randUser2 = randHash()
+const randUser3 = randHash()
 
 const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/
 Cypress.on('uncaught:exception', (err) => {
@@ -34,113 +36,129 @@ Cypress.on('uncaught:exception', (err) => {
 describe('Manage shared albums', () => {
   before(() => {
     cy.logout()
+
     cy.nextcloudCreateUser(randUser, 'password')
     cy.nextcloudCreateUser(randUser2, 'password')
-
-    cy.login(randUser, 'password')
-    cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
-    cy.createAnAlbumFromAlbums('shared_album_test1')
-    cy.addCollaborators([randUser2])
-    cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
-    cy.createAnAlbumFromAlbums('shared_album_test2')
-    cy.addCollaborators([randUser2])
-    cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
-    cy.createAnAlbumFromAlbums('shared_album_test3')
-    cy.addCollaborators([randUser2])
-    cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
-    cy.createAnAlbumFromAlbums('shared_album_test4')
-    cy.addCollaborators([randUser2])
-    cy.logout()
+    cy.nextcloudCreateUser(randUser3, 'password')
 
     cy.login(randUser2, 'password')
     cy.uploadTestMedia()
-    cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/sharedalbums`)
-    cy.goToSharedAlbum('shared_album_test2')
-    cy.addFilesToAlbumFromAlbum('shared_album_test2', [0, 1, 2])
-
-    // wait a bit for things to be settled
-    cy.wait(1000)
+    cy.logout()
   })
 
   beforeEach(() => {
-    cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/sharedalbums`)
-  })
-
-  it('Add and remove a file to a shared album from a shared album', () => {
-    cy.goToSharedAlbum('shared_album_test1')
-    cy.get('[data-test="media"]').should('have.length', 0)
-    cy.addFilesToAlbumFromAlbum('shared_album_test1', [0])
-    cy.get('[data-test="media"]').should('have.length', 1)
-    cy.selectMedia([0])
-    cy.removeSelectionFromAlbum()
-    cy.get('[data-test="media"]').should('have.length', 0)
-  })
-
-  it('Add and remove multiple files to a shared album from a shared album', () => {
-    cy.goToSharedAlbum('shared_album_test1')
-    cy.get('[data-test="media"]').should('have.length', 0)
-    cy.addFilesToAlbumFromAlbum('shared_album_test1', [1, 2])
-    cy.get('[data-test="media"]').should('have.length', 2)
-    cy.selectMedia([0, 1])
-    cy.removeSelectionFromAlbum()
-    cy.get('[data-test="media"]').should('have.length', 0)
-  })
-
-  it('Download a file from a shared album', () => {
-    cy.goToSharedAlbum('shared_album_test2')
-    cy.selectMedia([0])
-    cy.downloadSelection()
-    cy.unselectMedia([0])
-  })
-
-  it('Download multiple files from a shared album', () => {
-    cy.goToSharedAlbum('shared_album_test2')
-    cy.selectMedia([1, 2])
-    cy.downloadSelection()
-    cy.unselectMedia([1, 2])
-  })
-
-  it('Download all files from a shared album', () => {
-    cy.goToSharedAlbum('shared_album_test2')
-    cy.downloadAllFiles()
-  })
-
-  it('Remove a file from a shared album', () => {
-    cy.goToSharedAlbum('shared_album_test2')
-    cy.get('[data-test="media"]').should('have.length', 3)
-    cy.goToSharedAlbum('shared_album_test2')
-    cy.selectMedia([0])
-    cy.removeSelectionFromAlbum()
-    cy.get('[data-test="media"]').should('have.length', 2)
-  })
-
-  it('Remove multiple files from a shared album', () => {
-    cy.goToSharedAlbum('shared_album_test2')
-    cy.get('[data-test="media"]').should('have.length', 2)
-    cy.goToSharedAlbum('shared_album_test2')
-    cy.selectMedia([0, 1])
-    cy.removeSelectionFromAlbum()
-    cy.get('[data-test="media"]').should('have.length', 0)
-  })
-
-  it('Remove shared album', () => {
-    cy.goToSharedAlbum('shared_album_test3')
-    cy.removeSharedAlbums()
-  })
-
-  it('Remove collaborator from an album', () => {
-    cy.get('ul.collections__list li').should('have.length', 4)
-
     cy.logout()
-    cy.login(randUser, 'password')
-    cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos`)
-    cy.goToAlbum('shared_album_test4')
-    cy.removeCollaborators([randUser2])
-    cy.logout()
-
     cy.login(randUser2, 'password')
     cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/sharedalbums`)
+  })
 
-    cy.get('ul.collections__list li').should('have.length', 3)
+  context('Adding and removing files in a shared album', () => {
+    before(() => {
+      cy.logout()
+      cy.login(randUser, 'password')
+      cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
+      cy.createAnAlbumFromAlbums('shared_album_test1')
+      cy.addCollaborators([randUser2])
+      cy.logout()
+    })
+
+    it('Add and remove a file to a shared album from a shared album', () => {
+      cy.goToSharedAlbum('shared_album_test1')
+      cy.get('[data-test="media"]').should('have.length', 0)
+      cy.addFilesToAlbumFromAlbum('shared_album_test1', [0])
+      cy.get('[data-test="media"]').should('have.length', 1)
+      cy.selectMedia([0])
+      cy.removeSelectionFromAlbum()
+      cy.get('[data-test="media"]').should('have.length', 0)
+    })
+
+    it('Add and remove multiple files to a shared album from a shared album', () => {
+      cy.goToSharedAlbum('shared_album_test1')
+      cy.get('[data-test="media"]').should('have.length', 0)
+      cy.addFilesToAlbumFromAlbum('shared_album_test1', [1, 2])
+      cy.get('[data-test="media"]').should('have.length', 2)
+      cy.selectMedia([0, 1])
+      cy.removeSelectionFromAlbum()
+      cy.get('[data-test="media"]').should('have.length', 0)
+    })
+  })
+
+  context('Download files from a shared album', () => {
+    before(() => {
+      cy.logout()
+      cy.login(randUser, 'password')
+      cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
+      cy.createAnAlbumFromAlbums('shared_album_test2')
+      cy.addCollaborators([randUser2])
+      cy.logout()
+
+      cy.login(randUser2, 'password')
+      cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/sharedalbums`)
+      cy.goToSharedAlbum('shared_album_test2')
+      cy.addFilesToAlbumFromAlbum('shared_album_test2', [0, 1, 2])
+      cy.logout()
+    })
+
+    it('Download a file from a shared album', () => {
+      cy.goToSharedAlbum('shared_album_test2')
+      cy.selectMedia([0])
+      cy.downloadSelection()
+      cy.unselectMedia([0])
+    })
+
+    it('Download multiple files from a shared album', () => {
+      cy.goToSharedAlbum('shared_album_test2')
+      cy.selectMedia([1, 2])
+      cy.downloadSelection()
+      cy.unselectMedia([1, 2])
+    })
+
+    it('Download all files from a shared album', () => {
+      cy.goToSharedAlbum('shared_album_test2')
+      cy.downloadAllFiles()
+    })
+  })
+
+  context('Delete a received shared album', () => {
+    before(() => {
+      cy.logout()
+      cy.login(randUser, 'password')
+      cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
+      cy.createAnAlbumFromAlbums('shared_album_test3')
+      cy.addCollaborators([randUser2])
+      cy.logout()
+    })
+
+    it('Remove shared album', () => {
+      cy.goToSharedAlbum('shared_album_test3')
+      cy.removeSharedAlbums()
+    })
+  })
+
+  context('Remove a collaborator from an album', () => {
+    before(() => {
+      cy.logout()
+      cy.login(randUser, 'password')
+      cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/albums`)
+      cy.createAnAlbumFromAlbums('shared_album_test4')
+      cy.addCollaborators([randUser2])
+      cy.logout()
+    })
+
+    it('Remove collaborator from an album', () => {
+      cy.get('ul.collections__list li').should('have.length', 4)
+
+      cy.logout()
+      cy.login(randUser, 'password')
+      cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos`)
+      cy.goToAlbum('shared_album_test4')
+      cy.removeCollaborators([randUser2])
+      cy.logout()
+
+      cy.login(randUser2, 'password')
+      cy.visit(`${Cypress.env('baseUrl')}/index.php/apps/photos/sharedalbums`)
+
+      cy.get('ul.collections__list li').should('have.length', 3)
+    })
   })
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -243,7 +243,7 @@ Cypress.Commands.add('removeCollaborators', collaborators => {
 	cy.contains('Save').click()
 })
 
-Cypress.Commands.add('removeSharedAlbums', collaborators => {
+Cypress.Commands.add('removeSharedAlbums', () => {
 	cy.get('[aria-label="Open actions menu"]').click()
-	cy.contains("Remove selection from album").click()
+	cy.contains("Delete album").click()
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -232,8 +232,13 @@ Cypress.Commands.add('addCollaborators', collaborators => {
 Cypress.Commands.add('removeCollaborators', collaborators => {
 	cy.get('[aria-label="Manage collaborators for this album"]').click()
 	collaborators.forEach((collaborator) => {
-		cy.get('[aria-label="Search for collaborators"').type(collaborator)
-		cy.contains(collaborator).click()
+		cy.get('.manage-collaborators')
+			.within(() => {
+				cy.contains(collaborator)
+					.parentsUntil('ul')
+					.get(`[aria-label="Remove ${collaborator} from the collaborators list"]`)
+					.click()
+			})
 	})
 	cy.contains('Save').click()
 })

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -364,11 +364,11 @@ class AlbumMapper {
 			if ($row['fileid']) {
 				$mimeId = $row['mimetype'];
 				$mimeType = $this->mimeTypeLoader->getMimetypeById($mimeId);
-				$filesByAlbum[$albumId][] = new AlbumFile((int)$row['fileid'], $row['file_name'], $mimeType, (int)$row['size'], (int)$row['mtime'], $row['etag'], (int)$row['added'], $row['owner']);
+				$filesByAlbum[$albumId][] = new AlbumFile((int)$row['fileid'], $row['album_name'].' ('.$row['album_user'].')', $mimeType, (int)$row['size'], (int)$row['mtime'], $row['etag'], (int)$row['added'], $row['owner']);
 			}
 
 			if (!isset($albumsById[$albumId])) {
-				$albumsById[$albumId] = new AlbumInfo($albumId, $row['album_user'], $row['album_name'], $row['location'], (int)$row['created'], (int)$row['last_added_photo']);
+				$albumsById[$albumId] = new AlbumInfo($albumId, $row['album_user'], $row['album_name'].' ('.$row['album_user'].')', $row['location'], (int)$row['created'], (int)$row['last_added_photo']);
 			}
 		}
 
@@ -419,7 +419,7 @@ class AlbumMapper {
 			return new AlbumInfo(
 				(int)$row['album_id'],
 				$row['user'],
-				$row['name'],
+				$row['name'].' ('.$row['user'].')',
 				$row['location'],
 				(int)$row['created'],
 				(int)$row['last_added_photo']

--- a/src/components/Albums/CollaboratorsSelectionForm.vue
+++ b/src/components/Albums/CollaboratorsSelectionForm.vue
@@ -73,8 +73,7 @@
 				class="manage-collaborators__selection__item">
 				<NcListItemIcon :id="availableCollaborators[collaboratorKey].id"
 					:title="availableCollaborators[collaboratorKey].id"
-					:display-name="availableCollaborators[collaboratorKey].label"
-					:aria-label="t('photos', 'Remove {collaboratorLabel} from the collaborators list', {collaboratorLabel: availableCollaborators[collaboratorKey].label})">
+					:display-name="availableCollaborators[collaboratorKey].label">
 					<NcButton type="tertiary"
 						:aria-label="t('photos', 'Remove {collaboratorLabel} from the collaborators list', {collaboratorLabel: availableCollaborators[collaboratorKey].label})"
 						@click="unselectEntity(collaboratorKey)">

--- a/src/components/Albums/CollaboratorsSelectionForm.vue
+++ b/src/components/Albums/CollaboratorsSelectionForm.vue
@@ -45,7 +45,7 @@
 					<NcLoadingIcon v-if="loadingCollaborators" />
 				</label>
 
-				<ul :id="`manage-collaborators__form__list-${randomId}`" class="manage-collaborators__form__list">
+				<ul v-if="searchResults.length !== 0" :id="`manage-collaborators__form__list-${randomId}`" class="manage-collaborators__form__list">
 					<li v-for="result of searchResults" :key="result.key">
 						<a>
 							<NcListItemIcon :id="availableCollaborators[result.key].id"
@@ -58,6 +58,12 @@
 						</a>
 					</li>
 				</ul>
+				<NcEmptyContent v-else
+					key="emptycontent"
+					class="manage-collaborators__form__list--empty"
+					:title="t('photos', 'No collaborators available')">
+					<AccountGroup slot="icon" />
+				</NcEmptyContent>
 			</NcPopover>
 		</form>
 
@@ -116,13 +122,14 @@
 <script>
 import Magnify from 'vue-material-design-icons/Magnify'
 import Close from 'vue-material-design-icons/Close'
+import AccountGroup from 'vue-material-design-icons/AccountGroup'
 import Earth from 'vue-material-design-icons/Earth'
 
 import axios from '@nextcloud/axios'
 import { showError } from '@nextcloud/dialogs'
 import { getCurrentUser } from '@nextcloud/auth'
 import { generateOcsUrl } from '@nextcloud/router'
-import { NcButton, NcListItemIcon, NcLoadingIcon, NcPopover, NcTextField } from '@nextcloud/vue'
+import { NcButton, NcListItemIcon, NcLoadingIcon, NcPopover, NcTextField, NcEmptyContent } from '@nextcloud/vue'
 
 import logger from '../../services/logger.js'
 
@@ -140,12 +147,14 @@ export default {
 	components: {
 		Magnify,
 		Close,
+		AccountGroup,
 		Earth,
 		NcLoadingIcon,
 		NcButton,
 		NcListItemIcon,
 		NcTextField,
 		NcPopover,
+		NcEmptyContent,
 	},
 
 	props: {
@@ -354,6 +363,10 @@ export default {
 				&:hover {
 					background: var(--color-background-dark);
 				}
+			}
+
+			&--empty {
+				margin: 100px 0;
 			}
 		}
 	}

--- a/src/views/AlbumContent.vue
+++ b/src/views/AlbumContent.vue
@@ -379,12 +379,7 @@ export default {
 			this.showEditAlbumForm = false
 
 			if (this.album.basename !== album.basename) {
-				this.$router.push({
-					name: 'albums',
-					params: {
-						path: album.basename,
-					},
-				})
+				this.$router.push(`/albums/${album.basename}`)
 			}
 		},
 

--- a/src/views/Albums.vue
+++ b/src/views/Albums.vue
@@ -31,7 +31,6 @@
 				:title="t('photos', 'Albums')"
 				:root-title="t('photos', 'Albums')"
 				@refresh="onRefresh">
-				<slot name="header" />
 				<NcButton :aria-label="t('photos', 'Create a new album.')"
 					@click="showAlbumCreationForm = true">
 					<template #icon>

--- a/src/views/SharedAlbumContent.vue
+++ b/src/views/SharedAlbumContent.vue
@@ -54,7 +54,7 @@
 						</template>
 					</NcButton>
 
-					<NcActions :aria-label="t('photos', 'Open actions menu')">
+					<NcActions :force-menu="true" :aria-label="t('photos', 'Open actions menu')">
 						<ActionDownload v-if="albumFileIds.length > 0"
 							:selected-file-ids="albumFileIds"
 							:title="t('photos', 'Download all files in album')">

--- a/src/views/SharedAlbumContent.vue
+++ b/src/views/SharedAlbumContent.vue
@@ -290,6 +290,7 @@ export default {
 
 		async handleDeleteAlbum() {
 			await this.deleteSharedAlbum({ albumName: this.albumName })
+			this.$router.push('/sharedalbums')
 		},
 	},
 }

--- a/src/views/SharedAlbums.vue
+++ b/src/views/SharedAlbums.vue
@@ -26,6 +26,13 @@
 		:collection-root="t('photos', 'Shared albums')"
 		:error="errorFetchingAlbums"
 		class="albums-list">
+		<HeaderNavigation key="navigation"
+			slot="header"
+			:loading="loadingAlbums"
+			:title="t('photos', 'Shared albums')"
+			:root-title="t('photos', 'Shared albums')"
+			@refresh="onRefresh" />
+
 		<CollectionCover :key="collection.basename"
 			slot-scope="{collection}"
 			:link="`/sharedalbums/${collection.basename}`"
@@ -55,6 +62,7 @@ import { NcEmptyContent } from '@nextcloud/vue'
 import FetchSharedAlbumsMixin from '../mixins/FetchSharedAlbumsMixin.js'
 import CollectionsList from '../components/Collection/CollectionsList.vue'
 import CollectionCover from '../components/Collection/CollectionCover.vue'
+import HeaderNavigation from '../components/HeaderNavigation.vue'
 
 export default {
 	name: 'SharedAlbums',
@@ -63,6 +71,7 @@ export default {
 		NcEmptyContent,
 		CollectionsList,
 		CollectionCover,
+		HeaderNavigation,
 	},
 
 	filters: {
@@ -81,6 +90,12 @@ export default {
 	mixins: [
 		FetchSharedAlbumsMixin,
 	],
+
+	methods: {
+		onRefresh() {
+			this.fetchAlbums()
+		},
+	},
 }
 </script>
 <style lang="scss" scoped>


### PR DESCRIPTION
- Force menu for shared album content actions
- Correctly redirect on shared album deletion
- Add header to `SharedAlbums`
- Add `EmptyContent` in `CollaboratorSelectionForm`
- Refactor shared albums tests
- Support receiving two albums with the same names
- Add tests
    - to remove collaborator
    - to delete shared album
    - to edit album's name