### PR TITLE
Make photos_albums_files.owner nullable for beta migrations

### DIFF
--- a/lib/Migration/Version20001Date20220830131446.php
+++ b/lib/Migration/Version20001Date20220830131446.php
@@ -69,7 +69,7 @@ class Version20001Date20220830131446 extends SimpleMigrationStep {
 			$modified = true;
 			$table = $schema->getTable("photos_albums_files");
 			$table->addColumn('owner', Types::STRING, [
-				'notnull' => true,
+				'notnull' => false,
 				'length' => 64,
 			]);
 		}

--- a/lib/Migration/Version20001Date20220830131446.php
+++ b/lib/Migration/Version20001Date20220830131446.php
@@ -69,7 +69,8 @@ class Version20001Date20220830131446 extends SimpleMigrationStep {
 			$modified = true;
 			$table = $schema->getTable("photos_albums_files");
 			$table->addColumn('owner', Types::STRING, [
-				'notnull' => false,
+				'notnull' => true,
+				'default' => '',
 				'length' => 64,
 			]);
 		}


### PR DESCRIPTION
For https://github.com/nextcloud/photos/issues/1260 to unblock beta7