### PR TITLE
Disambiguate `album_id` on group by

### DIFF
--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -410,7 +410,7 @@ class AlbumMapper {
 			->where($query->expr()->eq('collaborator_id', $query->createNamedParameter($collaboratorId)))
 			->andWhere($query->expr()->eq('collaborator_type', $query->createNamedParameter($collaboratorType, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('file_id', $query->createNamedParameter($fileId)))
-			->groupBy('album_id')
+			->groupBy('a.album_id')
 			->executeQuery()
 			->fetchAll();
 


### PR DESCRIPTION
Fix:


```
[index] Error: OC\DB\Exceptions\DbalException: An exception occurred while executing a query: SQLSTATE[42702]: Ambiguous column: 7 ERROR:  column reference "album_id" is ambiguous
LINE 1: ...borator_type" = $2) AND ("file_id" = $3) GROUP BY "album_id"
                                                             ^ at <<closure>>

0. /var/www/tech-preview.nextcloud.com/lib/private/DB/QueryBuilder/QueryBuilder.php line 296
   OC\DB\Exceptions\DbalException::wrap()
1. /var/www/tech-preview.nextcloud.com/apps/photos/lib/Album/AlbumMapper.php line 414
   OC\DB\QueryBuilder\QueryBuilder->executeQuery()
2. /var/www/tech-preview.nextcloud.com/apps/photos/lib/Controller/PreviewController.php line 91
   OCA\Photos\Album\AlbumMapper->getAlbumForCollaboratorIdAndFileId()
3. /var/www/tech-preview.nextcloud.com/lib/private/AppFramework/Http/Dispatcher.php line 225
   OCA\Photos\Controller\PreviewController->index()
4. /var/www/tech-preview.nextcloud.com/lib/private/AppFramework/Http/Dispatcher.php line 133
   OC\AppFramework\Http\Dispatcher->executeController()
5. /var/www/tech-preview.nextcloud.com/lib/private/AppFramework/App.php line 172
   OC\AppFramework\Http\Dispatcher->dispatch()
6. /var/www/tech-preview.nextcloud.com/lib/private/Route/Router.php line 298
   OC\AppFramework\App::main()
7. /var/www/tech-preview.nextcloud.com/lib/base.php line 1047
   OC\Route\Router->match()
8. /var/www/tech-preview.nextcloud.com/index.php line 36
   OC::handleRequest()

GET /apps/photos/api/v1/preview/474?x=512&y=512
from 80.138.111.237 by christine at 2022-09-20T08:11:35+00:00
```