### PR TITLE
Allow album owner to get file added by collaborators

### DIFF
--- a/lib/Controller/PreviewController.php
+++ b/lib/Controller/PreviewController.php
@@ -88,7 +88,9 @@ class PreviewController extends Controller {
 		$nodes = $this->userFolder->getById($fileId);
 
 		if (\count($nodes) === 0) {
-			$albums = $this->albumMapper->getAlbumForCollaboratorIdAndFileId($user->getUID(), AlbumMapper::TYPE_USER, $fileId);
+			$albums = $this->albumMapper->getForUserAndFile($user->getUID(), $fileId);
+			$receivedAlbums = $this->albumMapper->getAlbumForCollaboratorIdAndFileId($user->getUID(), AlbumMapper::TYPE_USER, $fileId);
+			$albums = array_merge($albums, $receivedAlbums);
 
 			$userGroups = $this->groupManager->getUserGroupIds($user);
 			foreach ($userGroups as $groupId) {
@@ -98,8 +100,9 @@ class PreviewController extends Controller {
 			}
 
 			foreach ($albums as $album) {
+				$albumFile = $this->albumMapper->getForAlbumIdAndFileId($album->getId(), $fileId);
 				$nodes = $this->rootFolder
-					->getUserFolder($album->getUserId())
+					->getUserFolder($albumFile->getOwner())
 					->getById($fileId);
 				if (\count($nodes) !== 0) {
 					break;


### PR DESCRIPTION
When a collaborator adds a file to an album, the owner can't see a preview.

This is because I forgot to add the owner's albums to the list of albums to check. Also, retrieving the Node object was done relative to the album owner and not the photos owner.