### PR TITLE
Do not get all the files list when fetching the albums list

### DIFF
--- a/lib/Album/AlbumWithFiles.php
+++ b/lib/Album/AlbumWithFiles.php
@@ -25,11 +25,17 @@ namespace OCA\Photos\Album;
 
 class AlbumWithFiles {
 	private AlbumInfo $info;
+	private AlbumMapper $albumMapper;
+
 	/** @var AlbumFile[] */
 	private array $files;
 
-	public function __construct(AlbumInfo $info, array $files) {
+	public function __construct(
+		AlbumInfo $info,
+		AlbumMapper $albumMapper,
+		array $files = []) {
 		$this->info = $info;
+		$this->albumMapper = $albumMapper;
 		$this->files = $files;
 	}
 
@@ -41,6 +47,9 @@ class AlbumWithFiles {
 	 * @return AlbumFile[]
 	 */
 	public function getFiles(): array {
+		if (empty($this->files)) {
+			$this->files = $this->fetchFiles();
+		}
 		return $this->files;
 	}
 
@@ -48,6 +57,10 @@ class AlbumWithFiles {
 	 * @return AlbumFile[]
 	 */
 	public function addFile(AlbumFile $file): array {
+		if (empty($this->files)) {
+			$this->files = $this->fetchFiles();
+		}
+
 		array_push($this->files, $file);
 		return $this->files;
 	}
@@ -58,6 +71,13 @@ class AlbumWithFiles {
 	public function getFileIds(): array {
 		return array_map(function (AlbumFile $file) {
 			return $file->getFileId();
-		}, $this->files);
+		}, $this->getFiles());
+	}
+
+	/**
+	 * @return AlbumFile[]
+	 */
+	private function fetchFiles(): array {
+		return $this->albumMapper->getForAlbumIdAndUserWithFiles($this->info->getId(), $this->info->getUserId()) ?? [];
 	}
 }

--- a/lib/Sabre/Album/AlbumsHome.php
+++ b/lib/Sabre/Album/AlbumsHome.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Photos\Sabre\Album;
 
+use OCA\Photos\Album\AlbumInfo;
 use OCA\Photos\Album\AlbumMapper;
 use OCA\Photos\Album\AlbumWithFiles;
 use OCA\Photos\Service\UserConfigService;
@@ -106,10 +107,10 @@ class AlbumsHome implements ICollection {
 	 */
 	public function getChildren(): array {
 		if ($this->children === null) {
-			$folders = $this->albumMapper->getForUserWithFiles($this->user->getUID());
-			$this->children = array_map(function (AlbumWithFiles $folder) {
-				return new AlbumRoot($this->albumMapper, $folder, $this->rootFolder, $this->userFolder, $this->user, $this->userConfigService);
-			}, $folders);
+			$albumInfos = $this->albumMapper->getForUser($this->user->getUID());
+			$this->children = array_map(function (AlbumInfo $albumInfo) {
+				return new AlbumRoot($this->albumMapper, new AlbumWithFiles($albumInfo, $this->albumMapper), $this->rootFolder, $this->userFolder, $this->user, $this->userConfigService);
+			}, $albumInfos);
 		}
 
 		return $this->children;


### PR DESCRIPTION
Partial fix for https://github.com/nextcloud/photos/issues/1238

1. When propfind on the `/remote.php/dav/photos/admin/albums/`
    We used to fetch all albums WITH files. That meant fetching literally ALL the files in all albums for a specific user, so it will quickly get expensive
3. I moved the files cache on a per-album basis instead of on an album-root initialisation 


Advice welcome, we should also have psalm somewhere here! :see_no_evil: @CarlSchwan 