### PR TITLE
Limit auth backend to public albums

### DIFF
--- a/lib/Listener/SabrePluginAuthInitListener.php
+++ b/lib/Listener/SabrePluginAuthInitListener.php
@@ -43,6 +43,11 @@ class SabrePluginAuthInitListener implements IEventListener {
 		}
 
 		$server = $event->getServer();
+
+		if (!str_starts_with($server->getRequestUri(), 'photospublic/')) {
+			return;
+		}
+
 		$authPlugin = $server->getPlugin('auth');
 		$authPlugin->addBackend($this->publicAlbumAuthBackend);
 	}

--- a/lib/Sabre/PublicAlbumAuthBackend.php
+++ b/lib/Sabre/PublicAlbumAuthBackend.php
@@ -23,13 +23,11 @@ namespace OCA\Photos\Sabre;
 
 use OC\Security\Bruteforce\Throttler;
 use OCA\Photos\Album\AlbumMapper;
-use OCA\Photos\Album\AlbumWithFiles;
 use OCP\IRequest;
 use Sabre\DAV\Auth\Backend\AbstractBasic;
 
 class PublicAlbumAuthBackend extends AbstractBasic {
-	private const BRUTEFORCE_ACTION = 'public_webdav_auth';
-	private ?AlbumWithFiles $album = null;
+	private const BRUTEFORCE_ACTION = 'publicphotos_webdav_auth';
 	private IRequest $request;
 	private AlbumMapper $albumMapper;
 	private Throttler $throttler;
@@ -42,10 +40,6 @@ class PublicAlbumAuthBackend extends AbstractBasic {
 		$this->request = $request;
 		$this->albumMapper = $albumMapper;
 		$this->throttler = $throttler;
-
-		// setup realm
-		$defaults = new \OCP\Defaults();
-		$this->realm = $defaults->getName();
 	}
 
 	/**
@@ -60,21 +54,13 @@ class PublicAlbumAuthBackend extends AbstractBasic {
 
 		$albums = $this->albumMapper->getSharedAlbumsForCollaboratorWithFiles($username, AlbumMapper::TYPE_LINK);
 
-
 		if (count($albums) !== 1) {
 			$this->throttler->registerAttempt(self::BRUTEFORCE_ACTION, $this->request->getRemoteAddress());
 			return false;
 		}
 
-		$this->album = $albums[0];
-
 		\OC_User::setIncognitoMode(true);
 
 		return true;
-	}
-
-	public function getShare(): AlbumWithFiles {
-		assert($this->album !== null);
-		return $this->album;
 	}
 }


### PR DESCRIPTION
Fix https://github.com/nextcloud/photos/issues/1368

And clean `PublicAlbumAuthBackend.php` a bit.