### PR TITLE
Fix 'source' URL in viewer

### DIFF
--- a/src/components/Collection/CollectionContent.vue
+++ b/src/components/Collection/CollectionContent.vue
@@ -68,6 +68,7 @@ import FilesListViewer from '.././FilesListViewer.vue'
 import File from '.././File.vue'
 import FolderIllustration from '../../assets/Illustrations/folder.svg'
 import SemaphoreWithPriority from '../../utils/semaphoreWithPriority.js'
+import { toViewerFileInfo } from '../../utils/fileUtils.js'
 
 export default {
 	name: 'CollectionContent',
@@ -129,8 +130,8 @@ export default {
 		openViewer(fileId) {
 			const file = this.files[fileId]
 			OCA.Viewer.open({
-				fileInfo: file,
-				list: this.collectionFileIds.map(fileId => this.files[fileId]).filter(file => !file.sectionHeader),
+				fileInfo: toViewerFileInfo(file),
+				list: this.collectionFileIds.map(fileId => toViewerFileInfo(this.files[fileId])).filter(file => !file.sectionHeader),
 				loadMore: file.loadMore ? async () => await file.loadMore(true) : () => [],
 				canLoop: file.canLoop,
 			})

--- a/src/components/FileLegacy.vue
+++ b/src/components/FileLegacy.vue
@@ -60,6 +60,7 @@
 import { generateUrl } from '@nextcloud/router'
 
 import UserConfig from '../mixins/UserConfig.js'
+import { toViewerFileInfo } from '../utils/fileUtils.js'
 
 export default {
 	name: 'FileLegacy',
@@ -105,8 +106,8 @@ export default {
 	methods: {
 		openViewer() {
 			OCA.Viewer.open({
-				path: this.item.injected.filename,
-				list: this.item.injected.list,
+				fileInfo: toViewerFileInfo(this.item.injected),
+				list: this.item.injected.list.map(toViewerFileInfo),
 				loadMore: this.item.injected.loadMore ? async () => await this.item.injected.loadMore(true) : () => [],
 				canLoop: this.item.injected.canLoop,
 			})

--- a/src/mixins/FetchFacesMixin.js
+++ b/src/mixins/FetchFacesMixin.js
@@ -28,7 +28,7 @@ import { getCurrentUser } from '@nextcloud/auth'
 import client from '../services/DavClient.js'
 import logger from '../services/logger.js'
 import DavRequest from '../services/DavRequest'
-import { genFileInfo } from '../utils/fileUtils'
+import { genFileInfo, toAbsoluteFilePath } from '../utils/fileUtils'
 import AbortControllerMixin from './AbortControllerMixin'
 
 export default {
@@ -117,9 +117,12 @@ export default {
 					}
 				)
 
+				const fixRealpath = file => file.realpath.replace(`/${getCurrentUser().uid}/files`, '')
+
 				fetchedFiles = fetchedFiles
 					.map(file => genFileInfo(file))
-					.map(file => ({ ...file, filename: file.realpath.replace(`/${getCurrentUser().uid}/files`, '') }))
+					.map(file => ({ ...file, filename: toAbsoluteFilePath(fixRealpath(file)) }))
+					.map(file => genFileInfo(file)) // ensure we have a correct source URL
 
 				const fileIds = fetchedFiles.map(file => '' + file.fileid)
 

--- a/src/services/AlbumContent.js
+++ b/src/services/AlbumContent.js
@@ -22,7 +22,7 @@
 
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
-import { genFileInfo, encodeFilePath } from '../utils/fileUtils.js'
+import { genFileInfo, encodeFilePath, toRelativeFilePath } from '../utils/fileUtils.js'
 import allowedMimes from './AllowedMimes.js'
 
 /**
@@ -37,6 +37,7 @@ export default async function(path = '/', options = {}) {
 	const prefixPath = generateUrl(`/apps/photos/api/v1/${options.shared ? 'shared' : 'albums'}`)
 
 	// fetch listing
+	path = toRelativeFilePath(path)
 	const response = await axios.get(prefixPath + encodeFilePath(path), options)
 	const list = response.data.map(data => genFileInfo(data))
 
@@ -47,7 +48,7 @@ export default async function(path = '/', options = {}) {
 
 	for (const entry of list) {
 		// is this the current provided path ?
-		if (entry.filename === path) {
+		if (toRelativeFilePath(entry.filename) === path) {
 			folder = entry
 		} else if (entry.type !== 'file') {
 			folders.push(entry)

--- a/src/services/FileInfo.js
+++ b/src/services/FileInfo.js
@@ -20,9 +20,9 @@
  *
  */
 
-import client, { prefixPath } from './DavClient.js'
+import client from './DavClient.js'
 import request from './DavRequest.js'
-import { genFileInfo } from '../utils/fileUtils.js'
+import { genFileInfo, toAbsoluteFilePath } from '../utils/fileUtils.js'
 
 /**
  * Get a file info
@@ -32,10 +32,10 @@ import { genFileInfo } from '../utils/fileUtils.js'
  */
 export default async function(path) {
 	// getDirectoryContents doesn't accept / for root
-	const fixedPath = path === '/' ? '' : path
+	const fixedPath = toAbsoluteFilePath(path.endsWith('/') ? path.substring(0, -1) : path)
 
 	// fetch listing
-	const response = await client.stat(prefixPath + fixedPath, {
+	const response = await client.stat(fixedPath, {
 		data: request,
 		details: true,
 	})

--- a/src/services/FolderInfo.js
+++ b/src/services/FolderInfo.js
@@ -20,9 +20,9 @@
  *
  */
 
-import client, { prefixPath } from './DavClient.js'
+import client from './DavClient.js'
 import request from './DavRequest.js'
-import { genFileInfo } from '../utils/fileUtils.js'
+import { genFileInfo, toAbsoluteFilePath } from '../utils/fileUtils.js'
 
 /**
  * List files from a folder and filter out unwanted mimes
@@ -32,10 +32,10 @@ import { genFileInfo } from '../utils/fileUtils.js'
  */
 export default async function(path) {
 	// getDirectoryContents doesn't accept / for root
-	const fixedPath = path === '/' ? '' : path
+	const fixedPath = toAbsoluteFilePath(path.endsWith('/') ? path.substring(0, -1) : path)
 
 	// fetch listing
-	const response = await client.stat(prefixPath + fixedPath, {
+	const response = await client.stat(fixedPath, {
 		data: request,
 		details: true,
 	})

--- a/src/services/PhotoSearch.js
+++ b/src/services/PhotoSearch.js
@@ -20,7 +20,7 @@
  *
  */
 
-import { genFileInfo } from '../utils/fileUtils.js'
+import { genFileInfo, toRelativeFilePath } from '../utils/fileUtils.js'
 import { getCurrentUser } from '@nextcloud/auth'
 import { allMimes } from './AllowedMimes.js'
 import client from './DavClient.js'
@@ -52,6 +52,7 @@ export default async function(path = '', options = {}) {
 	}
 
 	const prefixPath = `/files/${getCurrentUser().uid}`
+	path = toRelativeFilePath(path)
 
 	// generating the search or condition
 	// based on the allowed mimetypes

--- a/src/services/TaggedImages.js
+++ b/src/services/TaggedImages.js
@@ -60,6 +60,4 @@ export default async function(id, options = {}) {
 		// hardcoded props and mime is not one of them
 		// https://github.com/nextcloud/server/blob/5bf3d1bb384da56adbf205752be8f840aac3b0c5/apps/dav/lib/Connector/Sabre/FilesReportPlugin.php#L274
 		.filter(file => file.mime && allowedMimes.indexOf(file.mime) !== -1)
-		// remove prefix path from full file path
-		.map(data => Object.assign({}, data, { filename: data.filename.replace(prefixPath, '') }))
 }

--- a/src/store/files.js
+++ b/src/store/files.js
@@ -25,7 +25,8 @@ import moment from '@nextcloud/moment'
 import { showError } from '@nextcloud/dialogs'
 
 import logger from '../services/logger.js'
-import client, { prefixPath } from '../services/DavClient.js'
+import client from '../services/DavClient.js'
+import { toRelativeFilePath } from '../utils/fileUtils.js'
 import Semaphore from '../utils/semaphoreWithPriority.js'
 
 const state = {
@@ -44,8 +45,8 @@ const mutations = {
 		const files = {}
 		newFiles.forEach(file => {
 			// Ignore the file if the path is excluded
-			if (state.nomediaPaths.some(nomediaPath => file.filename.startsWith(nomediaPath)
-				|| file.filename.startsWith(prefixPath + nomediaPath))) {
+			if (state.nomediaPaths.some(nomediaPath => toRelativeFilePath(file.filename).startsWith(nomediaPath))) {
+				logger.debug('Excluded file: ', file.filename)
 				return
 			}
 

--- a/src/views/FaceContent.vue
+++ b/src/views/FaceContent.vue
@@ -183,6 +183,7 @@ import FilesListViewer from '../components/FilesListViewer.vue'
 import File from '../components/File.vue'
 import logger from '../services/logger.js'
 import FetchFacesMixin from '../mixins/FetchFacesMixin.js'
+import { toViewerFileInfo } from '../utils/fileUtils.js'
 import Vue from 'vue'
 import FaceMergeForm from '../components/FaceMergeForm.vue'
 
@@ -286,11 +287,8 @@ export default {
 		openViewer(fileId) {
 			const file = this.files[fileId]
 			OCA.Viewer.open({
-				path: file.filename,
-				list: this.faceFileIds.map(fileId => ({
-					...this.files[fileId],
-					basename: this.files[fileId].basename.split('-').slice(1).join('-'),
-				})).filter(file => !file.sectionHeader),
+				path: toViewerFileInfo(file).filename,
+				list: this.faceFileIds.map(fileId => toViewerFileInfo(this.files[fileId])).filter(file => !file.sectionHeader),
 				loadMore: file.loadMore ? async () => await file.loadMore(true) : () => [],
 				canLoop: file.canLoop,
 			})

--- a/src/views/Folders.vue
+++ b/src/views/Folders.vue
@@ -42,7 +42,7 @@
 			:root-title="rootTitle"
 			@refresh="onRefresh">
 			<UploadPicker :accept="allowedMimes"
-				:destination="folder.filename"
+				:destination="toRelative(folder.filename)"
 				:multiple="true"
 				@uploaded="onUpload" />
 		</HeaderNavigation>
@@ -78,6 +78,7 @@ import getAlbumContent from '../services/AlbumContent.js'
 import AbortControllerMixin from '../mixins/AbortControllerMixin.js'
 import GridConfigMixin from '../mixins/GridConfig.js'
 import getFileInfo from '../services/FileInfo.js'
+import { toRelativeFilePath } from '../utils/fileUtils.js'
 
 export default {
 	name: 'Folders',
@@ -216,6 +217,10 @@ export default {
 	methods: {
 		onRefresh() {
 			this.fetchFolderContent()
+		},
+
+		toRelative(path) {
+			return toRelativeFilePath(path)
 		},
 
 		async fetchFolderContent() {

--- a/src/views/TagContent.vue
+++ b/src/views/TagContent.vue
@@ -75,6 +75,7 @@ import File from '../components/File.vue'
 import FilesListViewer from '../components/FilesListViewer.vue'
 
 import SemaphoreWithPriority from '../utils/semaphoreWithPriority.js'
+import { toViewerFileInfo } from '../utils/fileUtils.js'
 import FilesSelectionMixin from '../mixins/FilesSelectionMixin.js'
 import AbortControllerMixin from '../mixins/AbortControllerMixin.js'
 
@@ -175,8 +176,8 @@ export default {
 		openViewer(fileId) {
 			const file = this.files[fileId]
 			OCA.Viewer.open({
-				path: file.filename,
-				list: this.fileIds.map(fileId => this.files[fileId]),
+				fileInfo: toViewerFileInfo(file),
+				list: this.fileIds.map(fileId => toViewerFileInfo(this.files[fileId])),
 				loadMore: file.loadMore ? async () => await file.loadMore(true) : () => [],
 				canLoop: file.canLoop,
 			})

--- a/src/views/Timeline.vue
+++ b/src/views/Timeline.vue
@@ -136,6 +136,7 @@ import { NcModal, NcActions, NcActionButton, NcButton, NcEmptyContent, isMobile 
 import moment from '@nextcloud/moment'
 
 import { allMimes } from '../services/AllowedMimes.js'
+import { toViewerFileInfo } from '../utils/fileUtils.js'
 import FetchFilesMixin from '../mixins/FetchFilesMixin.js'
 import FilesByMonthMixin from '../mixins/FilesByMonthMixin.js'
 import FilesSelectionMixin from '../mixins/FilesSelectionMixin.js'
@@ -244,8 +245,8 @@ export default {
 		openViewer(fileId) {
 			const file = this.files[fileId]
 			OCA.Viewer.open({
-				fileInfo: file,
-				list: Object.values(this.fileIdsByMonth).flat().map(fileId => this.files[fileId]),
+				fileInfo: toViewerFileInfo(file),
+				list: Object.values(this.fileIdsByMonth).flat().map(fileId => toViewerFileInfo(this.files[fileId])),
 				loadMore: file.loadMore ? async () => await file.loadMore(true) : () => [],
 				canLoop: file.canLoop,
 			})


### PR DESCRIPTION
This PR concentrates on `filename` being consistent and includes app and user so that source URL can be built properly. This allows to use the full viewer (with fileInfo as input) at more places.

Prior to this change, source URL could be invalid and this broke sidebar, download and file-editing in the Viewer. The URL derives from `filename` but this was not consistently built (sometimes with, sometimes without prefix).

Since the viewer may also need different paths, all input to the viewer is mapped so that it can be adjusted as needed (at a single place).

Note: In my tests albums views still had an issue (e.g. forcing the use of the URL with `hasPreview: false` fails), but this may be related to https://github.com/nextcloud/viewer/issues/1282