### PR TITLE
Add primary key index to collaborators table

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>Photos</name>
     <summary>Your memories under your control</summary>
     <description>Your memories under your control</description>
-    <version>2.1.0</version>
+    <version>2.2.0</version>
     <licence>agpl</licence>
 	<author mail="skjnldsv@protonmail.com">John Molakvoæ</author>
     <namespace>Photos</namespace>

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -177,7 +177,7 @@ class AlbumMapper {
 		$query->executeStatement();
 
 		$query = $this->connection->getQueryBuilder();
-		$query->delete("photos_collaborators")
+		$query->delete("photos_albums_collabs")
 			->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
 		$query->executeStatement();
 
@@ -295,7 +295,7 @@ class AlbumMapper {
 	public function getCollaborators(int $albumId): array {
 		$query = $this->connection->getQueryBuilder();
 		$query->select("collaborator_id", "collaborator_type")
-			->from("photos_collaborators")
+			->from("photos_albums_collabs")
 			->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)));
 
 		$rows = $query->executeQuery()->fetchAll();
@@ -369,7 +369,7 @@ class AlbumMapper {
 			}
 
 			$query = $this->connection->getQueryBuilder();
-			$query->insert('photos_collaborators')
+			$query->insert('photos_albums_collabs')
 				->setValue('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT))
 				->setValue('collaborator_id', $query->createNamedParameter($collaborator['id']))
 				->setValue('collaborator_type', $query->createNamedParameter($collaborator['type'], IQueryBuilder::PARAM_INT))
@@ -378,7 +378,7 @@ class AlbumMapper {
 
 		foreach ($collaboratorsToRemove as $collaborator) {
 			$query = $this->connection->getQueryBuilder();
-			$query->delete('photos_collaborators')
+			$query->delete('photos_albums_collabs')
 				->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
 				->andWhere($query->expr()->eq('collaborator_id', $query->createNamedParameter($collaborator['id'])))
 				->andWhere($query->expr()->eq('collaborator_type', $query->createNamedParameter($collaborator['type'], IQueryBuilder::PARAM_INT)))
@@ -400,7 +400,7 @@ class AlbumMapper {
 			->selectAlias("f.name", "file_name")
 			->selectAlias("a.name", "album_name")
 			->selectAlias("a.user", "album_user")
-			->from("photos_collaborators", "c")
+			->from("photos_albums_collabs", "c")
 			->leftJoin("c", "photos_albums", "a", $query->expr()->eq("a.album_id", "c.album_id"))
 			->leftJoin("a", "photos_albums_files", "p", $query->expr()->eq("a.album_id", "p.album_id"))
 			->leftJoin("p", "filecache", "f", $query->expr()->eq("p.file_id", "f.fileid"))
@@ -445,7 +445,7 @@ class AlbumMapper {
 	public function deleteUserFromAlbumCollaboratorsList(string $userId, int $albumId): void {
 		// TODO: only delete if this was not a group share
 		$query = $this->connection->getQueryBuilder();
-		$query->delete('photos_collaborators')
+		$query->delete('photos_albums_collabs')
 			->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
 			->andWhere($query->expr()->eq('collaborator_id', $query->createNamedParameter($userId)))
 			->andWhere($query->expr()->eq('collaborator_type', $query->createNamedParameter(self::TYPE_USER, IQueryBuilder::PARAM_INT)))
@@ -462,7 +462,7 @@ class AlbumMapper {
 		$query = $this->connection->getQueryBuilder();
 		$rows = $query
 			->select("a.album_id", "name", "user", "location", "created", "last_added_photo")
-			->from("photos_collaborators", "c")
+			->from("photos_albums_collabs", "c")
 			->leftJoin("c", "photos_albums", "a", $query->expr()->eq("a.album_id", "c.album_id"))
 			->leftJoin("a", "photos_albums_files", "p", $query->expr()->eq("a.album_id", "p.album_id"))
 			->where($query->expr()->eq('collaborator_id', $query->createNamedParameter($collaboratorId)))

--- a/lib/Migration/Version20003Date20221102170153.php
+++ b/lib/Migration/Version20003Date20221102170153.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2022 Louis Chemineau <louis@chmn.me>
+ *
+ * @author Louis Chemineau <louis@chmn.me>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\Migration;
+
+use Closure;
+use OCP\IDBConnection;
+use OCP\DB\Types;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version20003Date20221102170153 extends SimpleMigrationStep {
+	protected IDBConnection $connection;
+
+	public function __construct(IDBConnection $connection) {
+		$this->connection = $connection;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable("photos_albums_collabs")) {
+			return null;
+		}
+
+		$table = $schema->createTable("photos_albums_collabs");
+		$table->addColumn('id', Types::BIGINT, [
+			'autoincrement' => true,
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('album_id', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 20,
+		]);
+		$table->addColumn('collaborator_id', Types::STRING, [
+			'notnull' => true,
+			'length' => 64,
+		]);
+		$table->addColumn('collaborator_type', Types::INTEGER, [
+			'notnull' => true,
+		]);
+
+		$table->setPrimaryKey(['id']);
+		$table->addUniqueIndex(['album_id', 'collaborator_id', 'collaborator_type'], 'album_collabs_uniq_collab');
+
+		return $schema;
+	}
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return void
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		if (!$schema->hasTable('photos_collaborators')) {
+			return;
+		}
+
+		$insert = $this->connection->getQueryBuilder();
+		$insert->insert('photos_albums_collabs')
+			->values([
+				'album_id' => $insert->createParameter('album_id'),
+				'collaborator_id' => $insert->createParameter('collaborator_id'),
+				'collaborator_type' => $insert->createParameter('collaborator_type'),
+			]);
+
+		$select = $this->connection->getQueryBuilder();
+		$select->select('*')
+			->from('photos_collaborators')
+			->setMaxResults(1000);
+
+		$offset = 0;
+		$movedRows = 0;
+		do {
+			$movedRows = $this->chunkedCopying($insert, $select, $offset);
+			$offset += $movedRows;
+		} while ($movedRows !== 0);
+	}
+
+	protected function chunkedCopying(IQueryBuilder $insert, IQueryBuilder $select, int $offset): int {
+		$this->connection->beginTransaction();
+
+		$result = $select
+			->setFirstResult($offset)
+			->executeQuery();
+
+		while ($row = $result->fetch()) {
+			$insert
+				->setParameter('album_id', (int)$row['album_id'], IQueryBuilder::PARAM_INT)
+				->setParameter('collaborator_id', $row['collaborator_id'])
+				->setParameter('collaborator_type', (int) $row['collaborator_type'], IQueryBuilder::PARAM_INT)
+				->executeStatement();
+		}
+
+		$result->closeCursor();
+		$this->connection->commit();
+
+		return $result->rowCount();
+	}
+}

--- a/lib/Migration/Version20003Date20221103094628.php
+++ b/lib/Migration/Version20003Date20221103094628.php
@@ -27,7 +27,6 @@ declare(strict_types=1);
 namespace OCA\Photos\Migration;
 
 use Closure;
-use OCP\DB\Types;
 use OCP\DB\ISchemaWrapper;
 use OCP\Migration\IOutput;
 use OCP\Migration\SimpleMigrationStep;
@@ -35,7 +34,7 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Auto-generated migration step: Please modify to your needs!
  */
-class Version20001Date20220830131446 extends SimpleMigrationStep {
+class Version20003Date20221103094628 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
@@ -45,43 +44,12 @@ class Version20001Date20220830131446 extends SimpleMigrationStep {
 	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
-		$modified = false;
 
-		/**
-		 * Replaced by Version20003Date20221102170153
-		 *
-		 * if (!$schema->hasTable("photos_collaborators")) {
-		 * 	$modified = true;
-		 * 	$table = $schema->createTable("photos_collaborators");
-		 * 	$table->addColumn('album_id', Types::BIGINT, [
-		 * 		'notnull' => true,
-		 * 		'length' => 20,
-		 * 	]);
-		 * 	$table->addColumn('collaborator_id', Types::STRING, [
-		 * 		'notnull' => true,
-		 * 		'length' => 64,
-		 * 	]);
-		 * 	$table->addColumn('collaborator_type', Types::INTEGER, [
-		 * 		'notnull' => true,
-		 * 	]);
-		 *
-		 * 	$table->addUniqueConstraint(['album_id', 'collaborator_id', 'collaborator_type'], 'collaborators_unique_idx');
-		 * }
-		 */
-
-		if (!$schema->getTable("photos_albums_files")->hasColumn("owner")) {
-			$modified = true;
-			$table = $schema->getTable("photos_albums_files");
-			$table->addColumn('owner', Types::STRING, [
-				'notnull' => false,
-				'length' => 64,
-			]);
-		}
-
-		if ($modified) {
+		if ($schema->hasTable('photos_collaborators')) {
+			$schema->dropTable('photos_collaborators');
 			return $schema;
-		} else {
-			return null;
 		}
+
+		return null;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "photos",
 	"description": "Your memories under your control",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"author": "John Molakvoæ <skjnldsv@protonmail.com>",
 	"contributors": [
 		"John Molakvoæ <skjnldsv@protonmail.com>"


### PR DESCRIPTION
- Create new `photos_albums_collabs` table
     - with an `id` auto-incremented column
     - with a primary key using the `id` column
     - with a unique index instead of a unique constraint
- Move data from `photos_collaborators` to `photos_albums_collabs`
- Delete `photos_collaborators` table

Should fix https://github.com/nextcloud/photos/issues/1285