### PR TITLE
Prevent throwing an error in node deletion hook

### DIFF
--- a/lib/Listener/CacheEntryRemovedListener.php
+++ b/lib/Listener/CacheEntryRemovedListener.php
@@ -19,10 +19,16 @@ class CacheEntryRemovedListener implements IEventListener {
 			return;
 		}
 
-		// Remove node from all albums containing it.
-		$albums = $this->albumMapper->getForFile($event->getFileId());
-		foreach ($albums as $album) {
-			$this->albumMapper->removeFile($album->getId(), $event->getFileId());
+		try {
+			// Remove node from all albums containing it.
+			$albums = $this->albumMapper->getForFile($event->getFileId());
+
+			foreach ($albums as $album) {
+				$this->albumMapper->removeFile($album->getId(), $event->getFileId());
+			}
+		} catch(\Throwable $ex) {
+			// If an error occur, return silently as we don't want to block the rest of the deletion process.
+			// It happened already during migrations when the albums table is not yet created, but a folder is deleted by the theming app.
 		}
 	}
 }


### PR DESCRIPTION
Not satisfied by this catch all approach. Maybe there are better ways to do that ? 

Fix https://github.com/nextcloud/server/issues/35287