### PR TITLE
Remove photos from collaborators once they are removed

### DIFF
--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -464,6 +464,20 @@ class AlbumMapper {
 			->andWhere($query->expr()->eq('collaborator_id', $query->createNamedParameter($userId)))
 			->andWhere($query->expr()->eq('collaborator_type', $query->createNamedParameter(self::TYPE_USER, IQueryBuilder::PARAM_INT)))
 			->executeStatement();
+
+		// Remove all photos by this user from the album:
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('photos_albums_files')
+			->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->eq('owner', $query->createNamedParameter($userId)))
+			->executeStatement();
+
+		// Update the last added photo:
+		$query = $this->connection->getQueryBuilder();
+		$query->update("photos_albums")
+			->set('last_added_photo', $query->createNamedParameter($this->getLastAdded($albumId), IQueryBuilder::PARAM_INT))
+			->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
+			->executeStatement();
 	}
 
 	/**

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -383,6 +383,20 @@ class AlbumMapper {
 				->andWhere($query->expr()->eq('collaborator_id', $query->createNamedParameter($collaborator['id'])))
 				->andWhere($query->expr()->eq('collaborator_type', $query->createNamedParameter($collaborator['type'], IQueryBuilder::PARAM_INT)))
 				->executeStatement();
+			
+			// Remove photos added by removed collaborators
+			$query = $this->connection->getQueryBuilder();
+			$query->delete('photos_albums_files')
+				->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
+				->andWhere($query->expr()->eq('owner', $query->createNamedParameter($collaborator['id'])))
+				->executeStatement();
+
+			// Update the last added photo after removal:
+			$query = $this->connection->getQueryBuilder();
+			$query->update("photos_albums")
+				->set('last_added_photo', $query->createNamedParameter($this->getLastAdded($albumId), IQueryBuilder::PARAM_INT))
+				->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)));
+			$query->executeStatement();
 		}
 
 		$this->connection->commit();


### PR DESCRIPTION
Right now photos stay in the album even after collaborators who added them either remove themselves from the album or are removed by the album owner.

Apart from the fact that accessing any photo that is not your own right now is utterly broken, I think when being removed from an album, also the respective user photos should be removed - they still own this data.

This MR attempts to implement this.

Please not that group sharing and photo adding is
a) not covered by this yet and
b) is completely broken (see https://github.com/nextcloud/photos/issues/1596)