### PR TITLE
Listen to NodeDeletedEvent to remove photos from albums

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -34,6 +34,7 @@ use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Files\Cache\CacheEntryRemovedEvent;
+use OCP\Files\Events\Node\NodeDeletedEvent;
 
 class Application extends App implements IBootstrap {
 	public const APP_ID = 'photos';
@@ -66,6 +67,7 @@ class Application extends App implements IBootstrap {
 		/** Register $principalBackend for the DAV collection */
 		$context->registerServiceAlias('principalBackend', Principal::class);
 		$context->registerEventListener(CacheEntryRemovedEvent::class, CacheEntryRemovedListener::class);
+		$context->registerEventListener(NodeDeletedEvent::class, CacheEntryRemovedListener::class);
 		$context->registerEventListener(SabrePluginAuthInitEvent::class, SabrePluginAuthInitListener::class);
 	}
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -28,12 +28,11 @@ namespace OCA\Photos\AppInfo;
 use OCA\DAV\Events\SabrePluginAuthInitEvent;
 use OCA\Photos\Listener\SabrePluginAuthInitListener;
 use OCA\DAV\Connector\Sabre\Principal;
-use OCA\Photos\Listener\CacheEntryRemovedListener;
+use OCA\Photos\Listener\NodeDeletedListener;
 use OCP\AppFramework\App;
 use OCP\AppFramework\Bootstrap\IBootContext;
 use OCP\AppFramework\Bootstrap\IBootstrap;
 use OCP\AppFramework\Bootstrap\IRegistrationContext;
-use OCP\Files\Cache\CacheEntryRemovedEvent;
 use OCP\Files\Events\Node\NodeDeletedEvent;
 
 class Application extends App implements IBootstrap {
@@ -66,8 +65,7 @@ class Application extends App implements IBootstrap {
 	public function register(IRegistrationContext $context): void {
 		/** Register $principalBackend for the DAV collection */
 		$context->registerServiceAlias('principalBackend', Principal::class);
-		$context->registerEventListener(CacheEntryRemovedEvent::class, CacheEntryRemovedListener::class);
-		$context->registerEventListener(NodeDeletedEvent::class, CacheEntryRemovedListener::class);
+		$context->registerEventListener(NodeDeletedEvent::class, NodeDeletedListener::class);
 		$context->registerEventListener(SabrePluginAuthInitEvent::class, SabrePluginAuthInitListener::class);
 	}
 


### PR DESCRIPTION
This MR adds a listener for `NodeDeletedEvent` which is emitted when deleting (or moving to trash bin) a file from *Files* or *Photos* itself. I don;t understand when the current `CacheEntryRemoved` event is emitted so I left it in - but someone with more insight into the NC ecosystem should probably have a look at this.

Also, I noted that this event `NodeDeletedEvent` is not documented in https://docs.nextcloud.com/server/latest/developer_manual/basics/events.html and the documented events such as `NodeRemovedFromCache` do not seem to be relevant here.

This fixes #1535 
