### PR TITLE
Fix upload of pictures into album

### DIFF
--- a/lib/Controller/PreviewController.php
+++ b/lib/Controller/PreviewController.php
@@ -101,7 +101,7 @@ class PreviewController extends Controller {
 
 		if (\count($nodes) === 0) {
 			$receivedAlbums = $this->albumMapper->getAlbumsForCollaboratorIdAndFileId($user->getUID(), AlbumMapper::TYPE_USER, $fileId);
-			$receivedAlbums = array_udiff($receivedAlbums, $checkedAlbums, fn ($a, $b) => strcmp($a->getId(), $b->getId()));
+			$receivedAlbums = array_udiff($receivedAlbums, $checkedAlbums, fn ($a, $b) => ($a->getId() - $b->getId()));
 			$nodes = $this->getFileIdForAlbums($fileId, $receivedAlbums);
 			$checkedAlbums = array_merge($checkedAlbums, $receivedAlbums);
 		}
@@ -110,7 +110,7 @@ class PreviewController extends Controller {
 			$userGroups = $this->groupManager->getUserGroupIds($user);
 			foreach ($userGroups as $groupId) {
 				$albumsForGroup = $this->albumMapper->getAlbumsForCollaboratorIdAndFileId($groupId, AlbumMapper::TYPE_GROUP, $fileId);
-				$albumsForGroup = array_udiff($albumsForGroup, $checkedAlbums, fn ($a, $b) => strcmp($a->getId(), $b->getId()));
+				$albumsForGroup = array_udiff($albumsForGroup, $checkedAlbums, fn ($a, $b) => ($a->getId() - $b->getId()));
 				$nodes = $this->getFileIdForAlbums($fileId, $albumsForGroup);
 				$checkedAlbums = array_merge($checkedAlbums, $receivedAlbums);
 				if (\count($nodes) !== 0) {

--- a/lib/Sabre/Album/AlbumRoot.php
+++ b/lib/Sabre/Album/AlbumRoot.php
@@ -95,10 +95,10 @@ class AlbumRoot implements ICollection, ICopyTarget {
 			[$photosLocation, $userFolder] = $this->getPhotosLocationInfo();
 
 			try {
-				$photosFolder = $this->userFolder->get($photosLocation);
+				$photosFolder = $userFolder->get($photosLocation);
 			} catch (NotFoundException $e) {
 				// If the folder does not exists, create it
-				$photosFolder = $this->userFolder->newFolder($photosLocation);
+				$photosFolder = $userFolder->newFolder($photosLocation);
 			}
 
 			// If the node is not a folder, we throw


### PR DESCRIPTION
Fixing two issues related to uploading pictures to albums:

* Album IDs were compared as strings but are `int`s
* Attempted to fetch user folder for storing uploaded photos from `$this` but it's only a local variable

There are still more issues to be solved here:
* Uploaded pictures do not show up in preview directly (i.e. need to reload page?)
* Still issues in adding pictures to group-shared albums (even when not uploading file we end in `createFile`...)
