### PR TITLE
Fix sharing with group

### DIFF
--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -349,7 +349,7 @@ class AlbumMapper {
 		foreach ($rows as $row) {
 			switch ($row['collaborator_type']) {
 				case self::TYPE_USER:
-					if (!strcmp($row['collaborator_id'], $userId)) {
+					if ($row['collaborator_id'] === $userId) {
 						return true;
 					}
 					break;

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -349,7 +349,7 @@ class AlbumMapper {
 		foreach ($rows as $row) {
 			switch ($row['collaborator_type']) {
 				case self::TYPE_USER:
-					if (strcmp($row['collaborator_id'], $userId)) {
+					if (!strcmp($row['collaborator_id'], $userId)) {
 						return true;
 					}
 					break;

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -349,12 +349,12 @@ class AlbumMapper {
 		foreach ($rows as $row) {
 			switch ($row['collaborator_type']) {
 				case self::TYPE_USER:
-					if ($row['collaborator_id'] === $userId) {
+					if (strcmp($row['collaborator_id'], $userId)) {
 						return true;
 					}
 					break;
 				case self::TYPE_GROUP:
-					if ($$this->groupManager->isInGroup($userId, $row['collaborator_id'])) {
+					if ($this->groupManager->isInGroup($userId, $row['collaborator_id'])) {
 						return true;
 					}
 					break;

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -332,6 +332,40 @@ class AlbumMapper {
 		return array_values(array_filter($collaborators, fn ($c) => $c !== null));
 	}
 
+
+	/**
+	 * @param int $albumId
+	 * @param string $userId
+	 * @return bool
+	 */
+	public function isCollaborator(int $albumId, string $userId): bool {
+		$query = $this->connection->getQueryBuilder();
+		$query->select("collaborator_id", "collaborator_type")
+			->from("photos_albums_collabs")
+			->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)));
+
+		$rows = $query->executeQuery()->fetchAll();
+
+		foreach ($rows as $row) {
+			switch ($row['collaborator_type']) {
+				case self::TYPE_USER:
+					if ($row['collaborator_id'] === $userId) {
+						return true;
+					}
+					break;
+				case self::TYPE_GROUP:
+					if ($$this->groupManager->isInGroup($userId, $row['collaborator_id'])) {
+						return true;
+					}
+					break;
+				default:
+					break;
+			}
+		}
+
+		return false;
+	}
+
 	/**
 	 * @param int $albumId
 	 * @param array{'id': string, 'type': int} $collaborators

--- a/lib/Sabre/Album/SharedAlbumRoot.php
+++ b/lib/Sabre/Album/SharedAlbumRoot.php
@@ -25,7 +25,6 @@ namespace OCA\Photos\Sabre\Album;
 
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\Conflict;
-use OCA\Photos\Album\AlbumMapper;
 
 class SharedAlbumRoot extends AlbumRoot {
 	/**
@@ -47,7 +46,7 @@ class SharedAlbumRoot extends AlbumRoot {
 			throw new Conflict("File $sourceId is already in the folder");
 		}
 
-		if(!$this->albumMapper->isCollaborator($this->album->getAlbum()->getId(), $this->userId)) {
+		if (!$this->albumMapper->isCollaborator($this->album->getAlbum()->getId(), $this->userId)) {
 			return false;
 		}
 

--- a/lib/Sabre/Album/SharedAlbumRoot.php
+++ b/lib/Sabre/Album/SharedAlbumRoot.php
@@ -47,11 +47,7 @@ class SharedAlbumRoot extends AlbumRoot {
 			throw new Conflict("File $sourceId is already in the folder");
 		}
 
-		$collaboratorIds = array_map(
-			fn ($collaborator) => $collaborator['type'].':'.$collaborator['id'],
-			$this->albumMapper->getCollaborators($this->album->getAlbum()->getId()),
-		);
-		if (!in_array(AlbumMapper::TYPE_USER.':'.$this->userId, $collaboratorIds)) {
+		if(!$this->albumMapper->isCollaborator($this->album->getAlbum()->getId(), $this->userId)) {
 			return false;
 		}
 


### PR DESCRIPTION
This MR fixes adding photos to an album shared to a group of users. The essential problem was that only collaboration via `userId` was checked.

This adds a new method to `AlbumMapper` to check for any given user ID of the user is a collaborator, no matter whether this is via direct sharing or group sharing.

This fixes #1596 