### PR TITLE
Fixes #1694: Public album sharing broken

### DIFF
--- a/lib/Sabre/Album/PublicAlbumRoot.php
+++ b/lib/Sabre/Album/PublicAlbumRoot.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\Photos\Sabre\Album;
 
+include_once("PublicAlbumPhoto.php");
 use OCA\Photos\Album\AlbumFile;
 use Sabre\DAV\Exception\Forbidden;
 use Sabre\DAV\Exception\NotFound;


### PR DESCRIPTION
class OCA\Photos\Sabre\Album\PublicAlbumPhoto is not available.
Fixes #1694: Public album sharing aborts with error.

/compile amend /