### PR TITLE
Install php deps on dev setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: dev-setup lint build-js-production test
 
 # Dev env management
-dev-setup: clean clean-dev npm-init
+dev-setup: clean clean-dev npm-init composer-install
 
 npm-init:
 	npm ci
@@ -50,3 +50,6 @@ clean:
 clean-dev:
 	rm -rf node_modules
 
+# Install php deps
+composer-install:
+	composer install


### PR DESCRIPTION
Currently the dev setup in readme does not mention that a `composer install` is required but it is. The effect is that, the plugin can't be activated on the admin figures this out and makes the install.