### PR TITLE
Prevent error on generating thumbnails

### DIFF
--- a/src/store/files.js
+++ b/src/store/files.js
@@ -51,6 +51,7 @@ const mutations = {
 
 			if (file.fileid >= 0) {
 				if (file.fileMetadataSize?.length > 1) {
+					file.fileMetadataSize = file.fileMetadataSize === '' ? '{}' : file.fileMetadataSize
 					file.fileMetadataSizeParsed = JSON.parse(file.fileMetadataSize?.replace(/&quot;/g, '"') ?? '{}')
 					file.fileMetadataSizeParsed.width = file.fileMetadataSizeParsed?.width ?? 256
 					file.fileMetadataSizeParsed.height = file.fileMetadataSizeParsed?.height ?? 256


### PR DESCRIPTION
When generating the thumbnails the parsing throws an error if the file property representing the image size metadata is an empty string. This protects the string by making it be a `"{}"` if the string is empty. This is described in [#1833](https://github.com/nextcloud/photos/issues/1833).