### PR TITLE
fix: use owner instead of owner_id to delete photos by owner

### DIFF
--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -298,7 +298,7 @@ class AlbumMapper {
 		$query = $this->connection->getQueryBuilder();
 		$albumsRows = $query->select('album_id')
 			->from("photos_albums_files")
-			->where($query->expr()->eq("owner_id", $query->createNamedParameter($ownerId)))
+			->where($query->expr()->eq("owner", $query->createNamedParameter($ownerId)))
 			->andWhere($query->expr()->eq("file_id", $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
 			->executeQuery()
 			->fetchAll();
@@ -306,7 +306,7 @@ class AlbumMapper {
 		// Remove any occurrence of fileId when owner is ownerId.
 		$query = $this->connection->getQueryBuilder();
 		$query->delete("photos_albums_files")
-			->where($query->expr()->eq("owner_id", $query->createNamedParameter($ownerId)))
+			->where($query->expr()->eq("owner", $query->createNamedParameter($ownerId)))
 			->andWhere($query->expr()->eq("file_id", $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
 			->executeStatement();
 


### PR DESCRIPTION
```
{
  "reqId": "",
  "level": 3,
  "time": "",
  "remoteAddr": "",
  "user": "",
  "app": "no app in context",
  "method": "DELETE",
  "url": "/ocs/v2.php/apps/files_sharing/api/v1/shares/900",
  "message": "An exception occurred while executing a query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'owner_id' in 'where clause'",
  "userAgent": "",
  "version": "25.0.7.2",
  "exception": {
    "Exception": "OC\\DB\\Exceptions\\DbalException",
    "Message": "An exception occurred while executing a query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'owner_id' in 'where clause'",
    "Code": 1054,
    "Trace": [
      {
        "file": "/var/www/html/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
        "line": 296,
        "function": "wrap",
        "class": "OC\\DB\\Exceptions\\DbalException",
        "type": "::"
      },
      {
        "file": "/var/www/html/nextcloud/apps/photos/lib/Album/AlbumMapper.php",
        "line": 303,
        "function": "executeQuery",
        "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
        "line": 55,
        "function": "removeFileWithOwner",
        "class": "OCA\\Photos\\Album\\AlbumMapper",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
        "line": 105,
        "function": "OCA\\Photos\\Listener\\{closure}",
        "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
        "type": "->",
        "args": [
          "*** sensitive parameters replaced ***"
        ]
      },
      {
        "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
        "line": 98,
        "function": "forEachSubNode",
        "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
        "line": 55,
        "function": "forEachSubNode",
        "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
        "line": 87,
        "function": "handle",
        "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 251,
        "function": "__invoke",
        "class": "OC\\EventDispatcher\\ServiceEventListener",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
        "line": 73,
        "function": "callListeners",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 88,
        "function": "dispatch",
        "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
        "line": 100,
        "function": "dispatch",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/Share20/Manager.php",
        "line": 1242,
        "function": "dispatchTyped",
        "class": "OC\\EventDispatcher\\EventDispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/apps/files_sharing/lib/Controller/ShareAPIController.php",
        "line": 444,
        "function": "deleteShare",
        "class": "OC\\Share20\\Manager",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 225,
        "function": "deleteShare",
        "class": "OCA\\Files_Sharing\\Controller\\ShareAPIController",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
        "line": 133,
        "function": "executeController",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/AppFramework/App.php",
        "line": 172,
        "function": "dispatch",
        "class": "OC\\AppFramework\\Http\\Dispatcher",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/lib/private/Route/Router.php",
        "line": 298,
        "function": "main",
        "class": "OC\\AppFramework\\App",
        "type": "::"
      },
      {
        "file": "/var/www/html/nextcloud/ocs/v1.php",
        "line": 64,
        "function": "match",
        "class": "OC\\Route\\Router",
        "type": "->"
      },
      {
        "file": "/var/www/html/nextcloud/ocs/v2.php",
        "line": 23,
        "args": [
          "/var/www/html/nextcloud/ocs/v1.php"
        ],
        "function": "require_once"
      }
    ],
    "File": "/var/www/html/nextcloud/lib/private/DB/Exceptions/DbalException.php",
    "Line": 72,
    "Previous": {
      "Exception": "Doctrine\\DBAL\\Exception\\InvalidFieldNameException",
      "Message": "An exception occurred while executing a query: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'owner_id' in 'where clause'",
      "Code": 1054,
      "Trace": [
        {
          "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
          "line": 1780,
          "function": "convert",
          "class": "Doctrine\\DBAL\\Driver\\API\\MySQL\\ExceptionConverter",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
          "line": 1719,
          "function": "handleDriverException",
          "class": "Doctrine\\DBAL\\Connection",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
          "line": 1067,
          "function": "convertExceptionDuringQuery",
          "class": "Doctrine\\DBAL\\Connection",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/DB/Connection.php",
          "line": 261,
          "function": "executeQuery",
          "class": "Doctrine\\DBAL\\Connection",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Query/QueryBuilder.php",
          "line": 345,
          "function": "executeQuery",
          "class": "OC\\DB\\Connection",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
          "line": 281,
          "function": "execute",
          "class": "Doctrine\\DBAL\\Query\\QueryBuilder",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
          "line": 294,
          "function": "execute",
          "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/apps/photos/lib/Album/AlbumMapper.php",
          "line": 303,
          "function": "executeQuery",
          "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
          "line": 55,
          "function": "removeFileWithOwner",
          "class": "OCA\\Photos\\Album\\AlbumMapper",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
          "line": 105,
          "function": "OCA\\Photos\\Listener\\{closure}",
          "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
          "type": "->",
          "args": [
            "*** sensitive parameters replaced ***"
          ]
        },
        {
          "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
          "line": 98,
          "function": "forEachSubNode",
          "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
          "line": 55,
          "function": "forEachSubNode",
          "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
          "line": 87,
          "function": "handle",
          "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
          "line": 251,
          "function": "__invoke",
          "class": "OC\\EventDispatcher\\ServiceEventListener",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
          "line": 73,
          "function": "callListeners",
          "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
          "line": 88,
          "function": "dispatch",
          "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
          "line": 100,
          "function": "dispatch",
          "class": "OC\\EventDispatcher\\EventDispatcher",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/Share20/Manager.php",
          "line": 1242,
          "function": "dispatchTyped",
          "class": "OC\\EventDispatcher\\EventDispatcher",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/apps/files_sharing/lib/Controller/ShareAPIController.php",
          "line": 444,
          "function": "deleteShare",
          "class": "OC\\Share20\\Manager",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 225,
          "function": "deleteShare",
          "class": "OCA\\Files_Sharing\\Controller\\ShareAPIController",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
          "line": 133,
          "function": "executeController",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/AppFramework/App.php",
          "line": 172,
          "function": "dispatch",
          "class": "OC\\AppFramework\\Http\\Dispatcher",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/lib/private/Route/Router.php",
          "line": 298,
          "function": "main",
          "class": "OC\\AppFramework\\App",
          "type": "::"
        },
        {
          "file": "/var/www/html/nextcloud/ocs/v1.php",
          "line": 64,
          "function": "match",
          "class": "OC\\Route\\Router",
          "type": "->"
        },
        {
          "file": "/var/www/html/nextcloud/ocs/v2.php",
          "line": 23,
          "args": [
            "/var/www/html/nextcloud/ocs/v1.php"
          ],
          "function": "require_once"
        }
      ],
      "File": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Driver/API/MySQL/ExceptionConverter.php",
      "Line": 65,
      "Previous": {
        "Exception": "Doctrine\\DBAL\\Driver\\PDO\\Exception",
        "Message": "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'owner_id' in 'where clause'",
        "Code": 1054,
        "Trace": [
          {
            "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Driver/PDO/Statement.php",
            "line": 94,
            "function": "new",
            "class": "Doctrine\\DBAL\\Driver\\PDO\\Exception",
            "type": "::"
          },
          {
            "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
            "line": 1057,
            "function": "execute",
            "class": "Doctrine\\DBAL\\Driver\\PDO\\Statement",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/DB/Connection.php",
            "line": 261,
            "function": "executeQuery",
            "class": "Doctrine\\DBAL\\Connection",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Query/QueryBuilder.php",
            "line": 345,
            "function": "executeQuery",
            "class": "OC\\DB\\Connection",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
            "line": 281,
            "function": "execute",
            "class": "Doctrine\\DBAL\\Query\\QueryBuilder",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
            "line": 294,
            "function": "execute",
            "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/apps/photos/lib/Album/AlbumMapper.php",
            "line": 303,
            "function": "executeQuery",
            "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
            "line": 55,
            "function": "removeFileWithOwner",
            "class": "OCA\\Photos\\Album\\AlbumMapper",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
            "line": 105,
            "function": "OCA\\Photos\\Listener\\{closure}",
            "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
            "type": "->",
            "args": [
              "*** sensitive parameters replaced ***"
            ]
          },
          {
            "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
            "line": 98,
            "function": "forEachSubNode",
            "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
            "line": 55,
            "function": "forEachSubNode",
            "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
            "line": 87,
            "function": "handle",
            "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
            "line": 251,
            "function": "__invoke",
            "class": "OC\\EventDispatcher\\ServiceEventListener",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
            "line": 73,
            "function": "callListeners",
            "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
            "line": 88,
            "function": "dispatch",
            "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
            "line": 100,
            "function": "dispatch",
            "class": "OC\\EventDispatcher\\EventDispatcher",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/Share20/Manager.php",
            "line": 1242,
            "function": "dispatchTyped",
            "class": "OC\\EventDispatcher\\EventDispatcher",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/apps/files_sharing/lib/Controller/ShareAPIController.php",
            "line": 444,
            "function": "deleteShare",
            "class": "OC\\Share20\\Manager",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
            "line": 225,
            "function": "deleteShare",
            "class": "OCA\\Files_Sharing\\Controller\\ShareAPIController",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
            "line": 133,
            "function": "executeController",
            "class": "OC\\AppFramework\\Http\\Dispatcher",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/AppFramework/App.php",
            "line": 172,
            "function": "dispatch",
            "class": "OC\\AppFramework\\Http\\Dispatcher",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/lib/private/Route/Router.php",
            "line": 298,
            "function": "main",
            "class": "OC\\AppFramework\\App",
            "type": "::"
          },
          {
            "file": "/var/www/html/nextcloud/ocs/v1.php",
            "line": 64,
            "function": "match",
            "class": "OC\\Route\\Router",
            "type": "->"
          },
          {
            "file": "/var/www/html/nextcloud/ocs/v2.php",
            "line": 23,
            "args": [
              "/var/www/html/nextcloud/ocs/v1.php"
            ],
            "function": "require_once"
          }
        ],
        "File": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Driver/PDO/Exception.php",
        "Line": 26,
        "Previous": {
          "Exception": "PDOException",
          "Message": "SQLSTATE[42S22]: Column not found: 1054 Unknown column 'owner_id' in 'where clause'",
          "Code": "42S22",
          "Trace": [
            {
              "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Driver/PDO/Statement.php",
              "line": 92,
              "function": "execute",
              "class": "PDOStatement",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Connection.php",
              "line": 1057,
              "function": "execute",
              "class": "Doctrine\\DBAL\\Driver\\PDO\\Statement",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/DB/Connection.php",
              "line": 261,
              "function": "executeQuery",
              "class": "Doctrine\\DBAL\\Connection",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Query/QueryBuilder.php",
              "line": 345,
              "function": "executeQuery",
              "class": "OC\\DB\\Connection",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
              "line": 281,
              "function": "execute",
              "class": "Doctrine\\DBAL\\Query\\QueryBuilder",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/DB/QueryBuilder/QueryBuilder.php",
              "line": 294,
              "function": "execute",
              "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/apps/photos/lib/Album/AlbumMapper.php",
              "line": 303,
              "function": "executeQuery",
              "class": "OC\\DB\\QueryBuilder\\QueryBuilder",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
              "line": 55,
              "function": "removeFileWithOwner",
              "class": "OCA\\Photos\\Album\\AlbumMapper",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
              "line": 105,
              "function": "OCA\\Photos\\Listener\\{closure}",
              "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
              "type": "->",
              "args": [
                "*** sensitive parameters replaced ***"
              ]
            },
            {
              "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
              "line": 98,
              "function": "forEachSubNode",
              "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/apps/photos/lib/Listener/AlbumsManagementEventListener.php",
              "line": 55,
              "function": "forEachSubNode",
              "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/ServiceEventListener.php",
              "line": 87,
              "function": "handle",
              "class": "OCA\\Photos\\Listener\\AlbumsManagementEventListener",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
              "line": 251,
              "function": "__invoke",
              "class": "OC\\EventDispatcher\\ServiceEventListener",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/3rdparty/symfony/event-dispatcher/EventDispatcher.php",
              "line": 73,
              "function": "callListeners",
              "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
              "line": 88,
              "function": "dispatch",
              "class": "Symfony\\Component\\EventDispatcher\\EventDispatcher",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/EventDispatcher/EventDispatcher.php",
              "line": 100,
              "function": "dispatch",
              "class": "OC\\EventDispatcher\\EventDispatcher",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/Share20/Manager.php",
              "line": 1242,
              "function": "dispatchTyped",
              "class": "OC\\EventDispatcher\\EventDispatcher",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/apps/files_sharing/lib/Controller/ShareAPIController.php",
              "line": 444,
              "function": "deleteShare",
              "class": "OC\\Share20\\Manager",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
              "line": 225,
              "function": "deleteShare",
              "class": "OCA\\Files_Sharing\\Controller\\ShareAPIController",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/AppFramework/Http/Dispatcher.php",
              "line": 133,
              "function": "executeController",
              "class": "OC\\AppFramework\\Http\\Dispatcher",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/AppFramework/App.php",
              "line": 172,
              "function": "dispatch",
              "class": "OC\\AppFramework\\Http\\Dispatcher",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/lib/private/Route/Router.php",
              "line": 298,
              "function": "main",
              "class": "OC\\AppFramework\\App",
              "type": "::"
            },
            {
              "file": "/var/www/html/nextcloud/ocs/v1.php",
              "line": 64,
              "function": "match",
              "class": "OC\\Route\\Router",
              "type": "->"
            },
            {
              "file": "/var/www/html/nextcloud/ocs/v2.php",
              "line": 23,
              "args": [
                "/var/www/html/nextcloud/ocs/v1.php"
              ],
              "function": "require_once"
            }
          ],
          "File": "/var/www/html/nextcloud/3rdparty/doctrine/dbal/src/Driver/PDO/Statement.php",
          "Line": 92
        }
      }
    },
    "CustomMessage": "--"
  }
}
```