### PR TITLE
Add OCC comand add-photo-to-album

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -33,6 +33,7 @@
     <commands>
         <command>OCA\Photos\Command\UpdateReverseGeocodingFilesCommand</command>
         <command>OCA\Photos\Command\AlbumAddCommand</command>
+        <command>OCA\Photos\Command\AlbumCreateCommand</command>
     </commands>
 
     <sabre>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,6 +32,7 @@
 
     <commands>
         <command>OCA\Photos\Command\UpdateReverseGeocodingFilesCommand</command>
+        <command>OCA\Photos\Command\AlbumAddCommand</command>
     </commands>
 
     <sabre>

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -122,9 +122,9 @@ class AlbumMapper {
 				->where($query->expr()->eq('name', $query->createNamedParameter($albumName)));
 		$row = $query->executeQuery()->fetch();
 		if ($row) {
-				return new AlbumInfo((int)$row['album_id'], $row['user'], $albumName, $row['location'], (int)$row['created'], (int)$row['last_added_photo']);
+			return new AlbumInfo((int)$row['album_id'], $row['user'], $albumName, $row['location'], (int)$row['created'], (int)$row['last_added_photo']);
 		} else {
-				return null;
+			return null;
 		}
 	}
 

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -110,6 +110,23 @@ class AlbumMapper {
 			return new AlbumInfo((int)$row['album_id'], $userId, $row['name'], $row['location'], (int)$row['created'], (int)$row['last_added_photo']);
 		}, $rows);
 	}
+	
+	/**
+	 * @param string $albumName
+	 * @return AlbumInfo
+	 */
+	public function getByName(string $albumName): ?AlbumInfo {
+		$query = $this->connection->getQueryBuilder();
+		$query->select("album_id", "user", "location", "created", "last_added_photo")
+				->from("photos_albums")
+				->where($query->expr()->eq('name', $query->createNamedParameter($albumName)));
+		$row = $query->executeQuery()->fetch();
+		if ($row) {
+				return new AlbumInfo((int)$row['album_id'], $row['user'], $albumName, $row['location'], (int)$row['created'], (int)$row['last_added_photo']);
+		} else {
+				return null;
+		}
+	}
 
 	/**
 	 * @param int $fileId

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -113,16 +113,18 @@ class AlbumMapper {
 	
 	/**
 	 * @param string $albumName
+	 * @param string $userName
 	 * @return AlbumInfo
 	 */
-	public function getByName(string $albumName): ?AlbumInfo {
+	public function getByName(string $albumName, string $userName): ?AlbumInfo {
 		$query = $this->connection->getQueryBuilder();
-		$query->select("album_id", "user", "location", "created", "last_added_photo")
+		$query->select("album_id", "location", "created", "last_added_photo")
 				->from("photos_albums")
-				->where($query->expr()->eq('name', $query->createNamedParameter($albumName)));
+				->where($query->expr()->eq('name', $query->createNamedParameter($albumName)))
+				->andWhere($query->expr()->eq('user', $query->createNamedParameter($userName)));
 		$row = $query->executeQuery()->fetch();
 		if ($row) {
-			return new AlbumInfo((int)$row['album_id'], $row['user'], $albumName, $row['location'], (int)$row['created'], (int)$row['last_added_photo']);
+			return new AlbumInfo((int)$row['album_id'], $userName, $albumName, $row['location'], (int)$row['created'], (int)$row['last_added_photo']);
 		} else {
 			return null;
 		}

--- a/lib/Command/AlbumAddCommand.php
+++ b/lib/Command/AlbumAddCommand.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Christian McHugh <mchugh19@hotmail.com>
+ *
+ * @author Christian McHugh <mchugh19@hotmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Photos\Command;
+
+use OCP\Files\IRootFolder;
+use OCP\IUserManager;
+use OCA\Photos\Album\AlbumMapper;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class AlbumAddCommand extends Command {
+        private IRootFolder $rootFolder;
+        private IUserManager $userManager;
+        private AlbumMapper $albumMapper;
+
+        public function __construct(
+                AlbumMapper $albumMapper,
+                IRootFolder $rootFolder,
+                IUserManager $userManager,
+        ) {
+                $this->rootFolder = $rootFolder;
+                $this->userManager = $userManager;
+                $this->albumMapper = $albumMapper;
+                parent::__construct();
+        }
+
+        /**
+         * Configure the command
+         */
+        protected function configure(): void {
+                $this->setName('photos:add-photo-to-album')
+                        ->setDescription('Add specified photo to album')
+                        ->addArgument('user', InputArgument::REQUIRED, 'user owning album')
+                        ->addArgument('album', InputArgument::REQUIRED, 'album name')
+                        ->addArgument('file', InputArgument::REQUIRED, 
+                                'Path to the file to add to the album. It must already be scanned and available in NextCloud. Example: Photos/picture1.jpg');
+        }
+
+        /**
+         * Execute the command
+         */
+        protected function execute(InputInterface $input, OutputInterface $output): int {
+                $userString = $input->getArgument('user');
+                $albumString = $input->getArgument('album');
+                $filePath = $input->getArgument('file');
+
+                $user = $this->userManager->get($userString);
+                if ($user === null) {
+                        throw new \Exception("User $userString was not found");
+                }
+                $userID = $user->getUID();
+
+                try {
+                        $pictureFileID = $this->rootFolder->getUserFolder($userID)->get($filePath)->getId();
+                } catch (\Exception $ex) {
+                        $output->writeln('<error>Invalid file path</error>');
+                        $output->writeln($ex->getMessage());
+                        return 1;
+                }
+
+                $retrievedAlbums = $this->albumMapper->getForUser($userString);
+
+                $album = null;
+                foreach ($retrievedAlbums as $singleAlbum) {
+                        if ($singleAlbum->getTitle() == $albumString) {
+                                $album = $singleAlbum;
+                                break;
+                        }
+                }
+
+                if (!$album) {
+                        throw new \Exception("Album $albumString was not found");
+                }
+
+                try {
+                        $this->albumMapper->addFile($album->getId(), $pictureFileID, $userID);
+
+                } catch (\Exception $ex) {
+                        $output->writeln("<error>Problem adding $filePath to $albumString</error>");
+                        $output->writeln($ex->getMessage());
+                        return 1;
+                }
+
+                return 0;
+        }
+}

--- a/lib/Command/AlbumAddCommand.php
+++ b/lib/Command/AlbumAddCommand.php
@@ -24,80 +24,78 @@ declare(strict_types=1);
  */
 namespace OCA\Photos\Command;
 
+use OCA\Photos\Album\AlbumMapper;
 use OCP\Files\IRootFolder;
 use OCP\IUserManager;
-use OCA\Photos\Album\AlbumMapper;
 
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-
 class AlbumAddCommand extends Command {
-        private IRootFolder $rootFolder;
-        private IUserManager $userManager;
-        private AlbumMapper $albumMapper;
+	private IRootFolder $rootFolder;
+	private IUserManager $userManager;
+	private AlbumMapper $albumMapper;
 
-        public function __construct(
-                AlbumMapper $albumMapper,
-                IRootFolder $rootFolder,
-                IUserManager $userManager,
-        ) {
-                $this->rootFolder = $rootFolder;
-                $this->userManager = $userManager;
-                $this->albumMapper = $albumMapper;
-                parent::__construct();
-        }
+	public function __construct(
+		AlbumMapper $albumMapper,
+		IRootFolder $rootFolder,
+		IUserManager $userManager,
+	) {
+		$this->rootFolder = $rootFolder;
+		$this->userManager = $userManager;
+		$this->albumMapper = $albumMapper;
+		parent::__construct();
+	}
 
-        /**
-         * Configure the command
-         */
-        protected function configure(): void {
-                $this->setName('photos:albums:add')
-                        ->setDescription('Add specified photo to album')
-                        ->addArgument('user', InputArgument::REQUIRED, 'User owning the album')
-                        ->addArgument('album', InputArgument::REQUIRED, 'Album name')
-                        ->addArgument('file', InputArgument::REQUIRED, 
-                                'Path of file to add to the album. It must already be scanned and available in NextCloud. Example: Photos/picture1.jpg');
-        }
+	/**
+	 * Configure the command
+	 */
+	protected function configure(): void {
+		$this->setName('photos:albums:add')
+				->setDescription('Add specified photo to album')
+				->addArgument('user', InputArgument::REQUIRED, 'User owning the album')
+				->addArgument('album', InputArgument::REQUIRED, 'Album name')
+				->addArgument('file', InputArgument::REQUIRED,
+					'Path of file to add to the album. It must already be scanned and available in NextCloud. Example: Photos/picture1.jpg');
+	}
 
-        /**
-         * Execute the command
-         */
-        protected function execute(InputInterface $input, OutputInterface $output): int {
-                $userString = $input->getArgument('user');
-                $albumString = $input->getArgument('album');
-                $filePath = $input->getArgument('file');
+	/**
+	 * Execute the command
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$userString = $input->getArgument('user');
+		$albumString = $input->getArgument('album');
+		$filePath = $input->getArgument('file');
 
-                $user = $this->userManager->get($userString);
-                if ($user === null) {
-                        throw new \Exception("User $userString was not found");
-                }
-                $userID = $user->getUID();
+		$user = $this->userManager->get($userString);
+		if ($user === null) {
+			throw new \Exception("User $userString was not found");
+		}
+		$userID = $user->getUID();
 
-                try {
-                        $pictureFileID = $this->rootFolder->getUserFolder($userID)->get($filePath)->getId();
-                } catch (\Exception $ex) {
-                        $output->writeln('<error>Invalid file path</error>');
-                        $output->writeln($ex->getMessage());
-                        return 1;
-                }
+		try {
+			$pictureFileID = $this->rootFolder->getUserFolder($userID)->get($filePath)->getId();
+		} catch (\Exception $ex) {
+			$output->writeln('<error>Invalid file path</error>');
+			$output->writeln($ex->getMessage());
+			return 1;
+		}
 
-                $album = $this->albumMapper->getByName($albumString);
-                if (!$album) {
-                        throw new \Exception("Album $albumString was not found");
-                }
+		$album = $this->albumMapper->getByName($albumString);
+		if (!$album) {
+			throw new \Exception("Album $albumString was not found");
+		}
 
-                try {
-                        $this->albumMapper->addFile($album->getId(), $pictureFileID, $userID);
-                } catch (\Exception $ex) {
-                        $output->writeln("<error>Problem adding $filePath to $albumString</error>");
-                        $output->writeln($ex->getMessage());
-                        return 1;
-                }
+		try {
+			$this->albumMapper->addFile($album->getId(), $pictureFileID, $userID);
+		} catch (\Exception $ex) {
+			$output->writeln("<error>Problem adding $filePath to $albumString</error>");
+			$output->writeln($ex->getMessage());
+			return 1;
+		}
 
-                return 0;
-        }
+		return 0;
+	}
 }

--- a/lib/Command/AlbumAddCommand.php
+++ b/lib/Command/AlbumAddCommand.php
@@ -57,8 +57,8 @@ class AlbumAddCommand extends Command {
         protected function configure(): void {
                 $this->setName('photos:add-photo-to-album')
                         ->setDescription('Add specified photo to album')
-                        ->addArgument('user', InputArgument::REQUIRED, 'user owning album')
-                        ->addArgument('album', InputArgument::REQUIRED, 'album name')
+                        ->addArgument('user', InputArgument::REQUIRED, 'User owning album')
+                        ->addArgument('album', InputArgument::REQUIRED, 'Album name')
                         ->addArgument('file', InputArgument::REQUIRED, 
                                 'Path to the file to add to the album. It must already be scanned and available in NextCloud. Example: Photos/picture1.jpg');
         }

--- a/lib/Command/AlbumAddCommand.php
+++ b/lib/Command/AlbumAddCommand.php
@@ -85,16 +85,7 @@ class AlbumAddCommand extends Command {
                         return 1;
                 }
 
-                $retrievedAlbums = $this->albumMapper->getForUser($userString);
-
-                $album = null;
-                foreach ($retrievedAlbums as $singleAlbum) {
-                        if ($singleAlbum->getTitle() == $albumString) {
-                                $album = $singleAlbum;
-                                break;
-                        }
-                }
-
+                $album = $this->albumMapper->getByName($albumString);
                 if (!$album) {
                         throw new \Exception("Album $albumString was not found");
                 }

--- a/lib/Command/AlbumAddCommand.php
+++ b/lib/Command/AlbumAddCommand.php
@@ -55,7 +55,7 @@ class AlbumAddCommand extends Command {
          * Configure the command
          */
         protected function configure(): void {
-                $this->setName('photos:add-photo-to-album')
+                $this->setName('photos:albums:add')
                         ->setDescription('Add specified photo to album')
                         ->addArgument('user', InputArgument::REQUIRED, 'User owning album')
                         ->addArgument('album', InputArgument::REQUIRED, 'Album name')

--- a/lib/Command/AlbumAddCommand.php
+++ b/lib/Command/AlbumAddCommand.php
@@ -83,7 +83,7 @@ class AlbumAddCommand extends Command {
 			return 1;
 		}
 
-		$album = $this->albumMapper->getByName($albumString);
+		$album = $this->albumMapper->getByName($albumString, $userString);
 		if (!$album) {
 			throw new \Exception("Album $albumString was not found");
 		}

--- a/lib/Command/AlbumAddCommand.php
+++ b/lib/Command/AlbumAddCommand.php
@@ -101,7 +101,6 @@ class AlbumAddCommand extends Command {
 
                 try {
                         $this->albumMapper->addFile($album->getId(), $pictureFileID, $userID);
-
                 } catch (\Exception $ex) {
                         $output->writeln("<error>Problem adding $filePath to $albumString</error>");
                         $output->writeln($ex->getMessage());

--- a/lib/Command/AlbumAddCommand.php
+++ b/lib/Command/AlbumAddCommand.php
@@ -57,10 +57,10 @@ class AlbumAddCommand extends Command {
         protected function configure(): void {
                 $this->setName('photos:albums:add')
                         ->setDescription('Add specified photo to album')
-                        ->addArgument('user', InputArgument::REQUIRED, 'User owning album')
+                        ->addArgument('user', InputArgument::REQUIRED, 'User owning the album')
                         ->addArgument('album', InputArgument::REQUIRED, 'Album name')
                         ->addArgument('file', InputArgument::REQUIRED, 
-                                'Path to the file to add to the album. It must already be scanned and available in NextCloud. Example: Photos/picture1.jpg');
+                                'Path of file to add to the album. It must already be scanned and available in NextCloud. Example: Photos/picture1.jpg');
         }
 
         /**

--- a/lib/Command/AlbumCreateCommand.php
+++ b/lib/Command/AlbumCreateCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022 Christian McHugh <mchugh19@hotmail.com>
+ *
+ * @author Christian McHugh <mchugh19@hotmail.com>
+ *
+ * @license AGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+namespace OCA\Photos\Command;
+
+use OCP\IUserManager;
+use OCA\Photos\Album\AlbumMapper;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+
+class AlbumCreateCommand extends Command {
+        private IUserManager $userManager;
+        private AlbumMapper $albumMapper;
+
+        public function __construct(
+                AlbumMapper $albumMapper,
+                IUserManager $userManager,
+        ) {
+                $this->userManager = $userManager;
+                $this->albumMapper = $albumMapper;
+                parent::__construct();
+        }
+
+        /**
+         * Configure the command
+         */
+        protected function configure(): void {
+                $this->setName('photos:create-album')
+                        ->setDescription('Add file to album')
+                        ->addArgument('user', InputArgument::REQUIRED, 'User to own album')
+                        ->addArgument('album', InputArgument::REQUIRED, 'Album name')
+                        ->addOption('location', 'l', InputOption::VALUE_REQUIRED, 'Set album location (optional)', "");
+        }
+
+        /**
+         * Execute the command
+         */
+        protected function execute(InputInterface $input, OutputInterface $output): int {
+                $userString = $input->getArgument('user');
+                $albumString = $input->getArgument('album');
+                $location = $input->getOption('location');
+
+                $user = $this->userManager->get($userString);
+                if ($user === null) {
+                        throw new \Exception("User $userString was not found");
+                }
+                $userID = $user->getUID();
+
+                $retrievedAlbums = $this->albumMapper->getForUser($userString);
+
+                $album = null;
+                foreach ($retrievedAlbums as $singleAlbum) {
+                        if ($singleAlbum->getTitle() == $albumString) {
+                                $album = $singleAlbum;
+                                break;
+                        }
+                }
+
+                if ($album) {
+                        throw new \Exception("Album $albumString already exists and cannot be created.");
+                }
+
+                try {
+                        $this->albumMapper->create($userID, $albumString, $location);
+                } catch (\Exception $ex) {
+                        $output->writeln('<error>Problem creating album</error>');
+                        $output->writeln($ex->getMessage());
+                        return 1;
+                }
+
+                return 0;
+        }
+}

--- a/lib/Command/AlbumCreateCommand.php
+++ b/lib/Command/AlbumCreateCommand.php
@@ -72,16 +72,7 @@ class AlbumCreateCommand extends Command {
                 }
                 $userID = $user->getUID();
 
-                $retrievedAlbums = $this->albumMapper->getForUser($userString);
-
-                $album = null;
-                foreach ($retrievedAlbums as $singleAlbum) {
-                        if ($singleAlbum->getTitle() == $albumString) {
-                                $album = $singleAlbum;
-                                break;
-                        }
-                }
-
+                $album = $this->albumMapper->getByName($albumString);
                 if ($album) {
                         throw new \Exception("Album $albumString already exists and cannot be created.");
                 }

--- a/lib/Command/AlbumCreateCommand.php
+++ b/lib/Command/AlbumCreateCommand.php
@@ -71,7 +71,7 @@ class AlbumCreateCommand extends Command {
 		}
 		$userID = $user->getUID();
 
-		$album = $this->albumMapper->getByName($albumString);
+		$album = $this->albumMapper->getByName($albumString, $userString);
 		if ($album) {
 			throw new \Exception("Album $albumString already exists and cannot be created.");
 		}

--- a/lib/Command/AlbumCreateCommand.php
+++ b/lib/Command/AlbumCreateCommand.php
@@ -51,8 +51,8 @@ class AlbumCreateCommand extends Command {
          * Configure the command
          */
         protected function configure(): void {
-                $this->setName('photos:create-album')
-                        ->setDescription('Add file to album')
+                $this->setName('photos:albums:create')
+                        ->setDescription('Create a new album for a user')
                         ->addArgument('user', InputArgument::REQUIRED, 'User to own album')
                         ->addArgument('album', InputArgument::REQUIRED, 'Album name')
                         ->addOption('location', 'l', InputOption::VALUE_REQUIRED, 'Set album location (optional)', "");

--- a/lib/Command/AlbumCreateCommand.php
+++ b/lib/Command/AlbumCreateCommand.php
@@ -24,67 +24,66 @@ declare(strict_types=1);
  */
 namespace OCA\Photos\Command;
 
-use OCP\IUserManager;
 use OCA\Photos\Album\AlbumMapper;
+use OCP\IUserManager;
 
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-
 class AlbumCreateCommand extends Command {
-        private IUserManager $userManager;
-        private AlbumMapper $albumMapper;
+	private IUserManager $userManager;
+	private AlbumMapper $albumMapper;
 
-        public function __construct(
-                AlbumMapper $albumMapper,
-                IUserManager $userManager,
-        ) {
-                $this->userManager = $userManager;
-                $this->albumMapper = $albumMapper;
-                parent::__construct();
-        }
+	public function __construct(
+		AlbumMapper $albumMapper,
+		IUserManager $userManager,
+	) {
+		$this->userManager = $userManager;
+		$this->albumMapper = $albumMapper;
+		parent::__construct();
+	}
 
-        /**
-         * Configure the command
-         */
-        protected function configure(): void {
-                $this->setName('photos:albums:create')
-                        ->setDescription('Create a new album for a user')
-                        ->addArgument('user', InputArgument::REQUIRED, 'User to own album')
-                        ->addArgument('album', InputArgument::REQUIRED, 'Album name')
-                        ->addOption('location', 'l', InputOption::VALUE_REQUIRED, 'Set album location (optional)', "");
-        }
+	/**
+	 * Configure the command
+	 */
+	protected function configure(): void {
+		$this->setName('photos:albums:create')
+				->setDescription('Create a new album for a user')
+				->addArgument('user', InputArgument::REQUIRED, 'User to own album')
+				->addArgument('album', InputArgument::REQUIRED, 'Album name')
+				->addOption('location', 'l', InputOption::VALUE_REQUIRED, 'Set album location (optional)', "");
+	}
 
-        /**
-         * Execute the command
-         */
-        protected function execute(InputInterface $input, OutputInterface $output): int {
-                $userString = $input->getArgument('user');
-                $albumString = $input->getArgument('album');
-                $location = $input->getOption('location');
+	/**
+	 * Execute the command
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
+		$userString = $input->getArgument('user');
+		$albumString = $input->getArgument('album');
+		$location = $input->getOption('location');
 
-                $user = $this->userManager->get($userString);
-                if ($user === null) {
-                        throw new \Exception("User $userString was not found");
-                }
-                $userID = $user->getUID();
+		$user = $this->userManager->get($userString);
+		if ($user === null) {
+			throw new \Exception("User $userString was not found");
+		}
+		$userID = $user->getUID();
 
-                $album = $this->albumMapper->getByName($albumString);
-                if ($album) {
-                        throw new \Exception("Album $albumString already exists and cannot be created.");
-                }
+		$album = $this->albumMapper->getByName($albumString);
+		if ($album) {
+			throw new \Exception("Album $albumString already exists and cannot be created.");
+		}
 
-                try {
-                        $this->albumMapper->create($userID, $albumString, $location);
-                } catch (\Exception $ex) {
-                        $output->writeln('<error>Problem creating album</error>');
-                        $output->writeln($ex->getMessage());
-                        return 1;
-                }
+		try {
+			$this->albumMapper->create($userID, $albumString, $location);
+		} catch (\Exception $ex) {
+			$output->writeln('<error>Problem creating album</error>');
+			$output->writeln($ex->getMessage());
+			return 1;
+		}
 
-                return 0;
-        }
+		return 0;
+	}
 }


### PR DESCRIPTION
Creates a simple CLI for creating an album and adding a photo file to an album.
```
# occ photos:albums:add xian "test from occ"

# occ photos:albums:create --help
Description:
  Create a new album for a user

Usage:
  photos:albums:create [options] [--] <user> <album>

Arguments:
  user                     User to own album
  album                    Album name

Options:
  -l, --location=LOCATION  Set album location (optional) [default: ""]
```
```
# occ photos:albums:add xian "Picnic 2023" "Photos/2023/08/P1010138.JPG"

# occ photos:albums:add --help
Description:
  Add specified photo to album

Usage:
  photos:albums:add <user> <album> <file>

Arguments:
  user                  User owning the album
  album                 Album name
  file                  Path of file to add to the album. It must already be scanned and available in NextCloud. Example: Photos/picture1.jpg
```