### PR TITLE
Fix Fatal Error in Album setCollaborator function - redefining computeKey function

### DIFF
--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -440,12 +440,12 @@ class AlbumMapper {
 		$existingCollaborators = $this->getCollaborators($albumId);
 
 		// Different behavior if type is link to prevent creating multiple link.
-		function computeKey($c) {
-			return ($c['type'] === AlbumMapper::TYPE_LINK ? '' : $c['id']).$c['type'];
-		}
+		$computeKey = function ($c) {
+			return ($c['type'] === AlbumMapper::TYPE_LINK ? '' : $c['id']) . $c['type'];
+		};
 
-		$collaboratorsToAdd = array_udiff($collaborators, $existingCollaborators, fn ($a, $b) => strcmp(computeKey($a), computeKey($b)));
-		$collaboratorsToRemove = array_udiff($existingCollaborators, $collaborators, fn ($a, $b) => strcmp(computeKey($a), computeKey($b)));
+		$collaboratorsToAdd = array_udiff($collaborators, $existingCollaborators, fn ($a, $b) => strcmp($computeKey($a), $computeKey($b)));
+		$collaboratorsToRemove = array_udiff($existingCollaborators, $collaborators, fn ($a, $b) => strcmp($computeKey($a), $computeKey($b)));
 
 		$this->connection->beginTransaction();
 


### PR DESCRIPTION
When calling setCollaborator function two times after another, computeKey is redefined and leads to a fatal error. Fixed by defining it as an anonymous function instead :)

I wrote an app, which calls this function, and thus I discovered that problem.