### PR TITLE
Request background job to generate metadata on non-local files

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -91,8 +91,11 @@ class Application extends App implements IBootstrap {
 
 		// Metadata
 		$context->registerEventListener(MetadataLiveEvent::class, ExifMetadataProvider::class);
+		$context->registerEventListener(MetadataBackgroundEvent::class, ExifMetadataProvider::class);
 		$context->registerEventListener(MetadataLiveEvent::class, SizeMetadataProvider::class);
+		$context->registerEventListener(MetadataBackgroundEvent::class, SizeMetadataProvider::class);
 		$context->registerEventListener(MetadataLiveEvent::class, OriginalDateTimeMetadataProvider::class);
+		$context->registerEventListener(MetadataBackgroundEvent::class, OriginalDateTimeMetadataProvider::class);
 		$context->registerEventListener(MetadataLiveEvent::class, PlaceMetadataProvider::class);
 		$context->registerEventListener(MetadataBackgroundEvent::class, PlaceMetadataProvider::class);
 

--- a/lib/Listener/ExifMetadataProvider.php
+++ b/lib/Listener/ExifMetadataProvider.php
@@ -26,6 +26,7 @@ use OCA\Photos\AppInfo\Application;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
 use OCP\Files\File;
+use OCP\FilesMetadata\Event\MetadataBackgroundEvent;
 use OCP\FilesMetadata\Event\MetadataLiveEvent;
 use Psr\Log\LoggerInterface;
 
@@ -42,13 +43,20 @@ class ExifMetadataProvider implements IEventListener {
 	}
 
 	public function handle(Event $event): void {
-		if (!($event instanceof MetadataLiveEvent)) {
+		if (!($event instanceof MetadataLiveEvent) && !($event instanceof MetadataBackgroundEvent)) {
 			return;
 		}
 
 		$node = $event->getNode();
 
 		if (!$node instanceof File || $node->getSize() === 0) {
+			return;
+		}
+
+		// We need the file content to extract the EXIF data.
+		// This can be slow for remote storage, so we do it in a background job.
+		if (!$node->getStorage()->isLocal() && $event instanceof MetadataLiveEvent) {
+			$event->requestBackgroundJob();
 			return;
 		}
 


### PR DESCRIPTION
For EXIF and size providers, we need the file content. That can take a lot of time for non-local storage. So for those providers, we request a background job when the file is non-local.
As the original date time provider depends on the EXIF provider, the same logic was applied. 