### PR TITLE
initMetadata on a repair step

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -49,4 +49,14 @@
     <background-jobs>
         <job>OCA\Photos\Jobs\AutomaticPlaceMapperJob</job>
     </background-jobs>
+
+    <repair-steps>
+        <install>
+            <step>OCA\Photos\RepairStep\InitMetadata</step>
+        </install>
+        <post-migration>
+            <step>OCA\Photos\RepairStep\InitMetadata</step>
+        </post-migration>
+    </repair-steps>
+
 </info>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -44,8 +44,6 @@ use OCP\AppFramework\Bootstrap\IRegistrationContext;
 use OCP\Files\Events\Node\NodeDeletedEvent;
 use OCP\FilesMetadata\Event\MetadataBackgroundEvent;
 use OCP\FilesMetadata\Event\MetadataLiveEvent;
-use OCP\FilesMetadata\IFilesMetadataManager;
-use OCP\FilesMetadata\Model\IMetadataValueWrapper;
 use OCP\Group\Events\GroupDeletedEvent;
 use OCP\Group\Events\UserRemovedEvent;
 use OCP\Security\CSP\AddContentSecurityPolicyEvent;
@@ -112,8 +110,5 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function boot(IBootContext $context): void {
-		/** @var IFilesMetadataManager $metadataManager */
-		$metadataManager = $context->getServerContainer()->get(IFilesMetadataManager::class);
-		$metadataManager->initMetadata('photos-original_date_time', IMetadataValueWrapper::TYPE_INT, true, IMetadataValueWrapper::EDIT_FORBIDDEN);
 	}
 }

--- a/lib/RepairStep/InitMetadata.php
+++ b/lib/RepairStep/InitMetadata.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @copyright Copyright (c) 2024 Maxence Lange <maxence@artificial-owl.com>
+ *
+ * @author Maxence Lange <maxence@artificial-owl.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\Photos\RepairStep;
+
+use OCP\FilesMetadata\IFilesMetadataManager;
+use OCP\FilesMetadata\Model\IMetadataValueWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\IRepairStep;
+
+class InitMetadata implements IRepairStep {
+	public function __construct(
+		private IFilesMetadataManager $metadataManager,
+	) {
+	}
+
+	public function getName() {
+		return 'init metadata';
+	}
+
+	public function run(IOutput $output) {
+		$this->metadataManager->initMetadata('photos-original_date_time', IMetadataValueWrapper::TYPE_INT, true, IMetadataValueWrapper::EDIT_FORBIDDEN);
+	}
+}


### PR DESCRIPTION
migrate the initMetadata to a repair step process instead of running it too frequently.
the idea is to (server-side) migrate known metadata to lazy appconfig 