### PR TITLE
fix(SizeMetadataProvider): Swap the width and height if the image is rotated

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -75,6 +75,7 @@ class Application extends App implements IBootstrap {
 		// Metadata
 		$context->registerEventListener(MetadataLiveEvent::class, ExifMetadataProvider::class);
 		$context->registerEventListener(MetadataBackgroundEvent::class, ExifMetadataProvider::class);
+		// SizeMetadataProvider optionally depends on ExifMetadataProvider, so it has to be registered afterwards
 		$context->registerEventListener(MetadataLiveEvent::class, SizeMetadataProvider::class);
 		$context->registerEventListener(MetadataBackgroundEvent::class, SizeMetadataProvider::class);
 		$context->registerEventListener(MetadataLiveEvent::class, OriginalDateTimeMetadataProvider::class);

--- a/lib/Listener/SizeMetadataProvider.php
+++ b/lib/Listener/SizeMetadataProvider.php
@@ -53,6 +53,22 @@ class SizeMetadataProvider implements IEventListener {
 			return;
 		}
 
+		// The image might have a rotation stored in the EXIF data.
+		// If that is the case and the rotation is 90/270 degrees the width and height need to be swapped.
+		// This is necessary because the clients will take the rotation into account when displaying the image.
+		if ($event->getMetadata()->hasKey('photos-ifd0')) {
+			$ifd0 = $event->getMetadata()->getArray('photos-ifd0');
+			if (array_key_exists('Orientation', $ifd0)) {
+				/** @var int $orientation */
+				$orientation = $ifd0['Orientation'];
+
+				// https://exiftool.org/TagNames/EXIF.html
+				if ($orientation >= 5) {
+					$size = [$size[1], $size[0]];
+				}
+			}
+		}
+
 		$event->getMetadata()->setArray('photos-size', [
 			'width' => $size[0],
 			'height' => $size[1],


### PR DESCRIPTION
Hi,
I'm not sure if this fixes make sense, but there is a problem with the current size calculation: The width and height are reported for the original unrotated version instead of the rotated version. This leads to the problem that clients relying on the WebDAV metadata or the rich object parameters when sending an image in Talk will display the image with the wrong dimensions. I'm not sure if this is a valid problem, but I don't see another way as not all places expose the full exif metadata (Talk) and letting the clients handle it is a bit tedious.

To fix this I just added this code to detect the rotation and swap the dimensions if necessary, but I'm not happy with this fix. It only works with the exif module enabled and the exif metadata is already read in the ExifMetadataProvider so this is duplicate. I think this fix would be cleaner if the functionality was moved to the ExifMetadataProvider so the exif data is only read once. If the exif module is not available we can still fallback to the current method of getting the image dimensions, but swapping the dimensions won't work.