### PR TITLE
fix: avoid erroring out on corrupt image data

### DIFF
--- a/lib/Listener/SizeMetadataProvider.php
+++ b/lib/Listener/SizeMetadataProvider.php
@@ -47,9 +47,10 @@ class SizeMetadataProvider implements IEventListener {
 			return;
 		}
 
-		$size = getimagesizefromstring($node->getContent());
+		$size = @getimagesizefromstring($node->getContent());
 
 		if ($size === false) {
+			$this->logger->debug('SizeMetadataProvider->handle(): Corrupt image data detected ' . $node->getPath());
 			return;
 		}
 


### PR DESCRIPTION
Fixes #2257
Fixes #2235 

As an aside, we should consider switching from using `getimagesizefromstring()` to `getimagesize()` if we can -- it consumes far less memory in my testing (presumably since the entire image isn't loaded into a string in memory). 

P.S. Technically this also addresses the logging side of #2259, but it's unclear whether that's arising from a memory limit or what. I can only get that error if I feed `getimagesizefromstring()` `/dev/null`. :-) However this PR does add logging of the path so it'll likely help work out that issue as well.