### PR TITLE
feat: Check upload directory share state

### DIFF
--- a/lib/Sabre/Album/AlbumRoot.php
+++ b/lib/Sabre/Album/AlbumRoot.php
@@ -14,6 +14,7 @@ use OCA\Photos\Album\AlbumMapper;
 use OCA\Photos\Album\AlbumWithFiles;
 use OCA\Photos\Service\UserConfigService;
 use OCP\Files\Folder;
+use OCP\Files\InvalidDirectoryException;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use Sabre\DAV\Exception\Conflict;
@@ -79,6 +80,10 @@ class AlbumRoot implements ICollection, ICopyTarget {
 			// If the node is not a folder, we throw
 			if (!($photosFolder instanceof Folder)) {
 				throw new Conflict('The destination exists and is not a folder');
+			}
+
+			if ($photosFolder->isShared()) {
+				throw new InvalidDirectoryException('The destination is a received share');
 			}
 
 			// Check for conflict and rename the file accordingly

--- a/src/components/PhotosPicker.vue
+++ b/src/components/PhotosPicker.vue
@@ -43,18 +43,25 @@
 
 		<!-- The actions on the bottom -->
 		<template #actions>
-			<UploadPicker :accept="allowedMimes"
-				:context="uploadContext"
-				:destination="photosLocationFolder"
-				:multiple="true"
-				@uploaded="refreshFiles" />
-			<NcButton type="primary" :disabled="loading || selectedFileIds.length === 0" @click="emitPickedEvent">
-				<template #icon>
-					<ImagePlus v-if="!loading" />
-					<NcLoadingIcon v-if="loading" />
-				</template>
-				{{ t('photos', 'Add to {destination}', { destination }) }}
-			</NcButton>
+			<div class="photos-picker__actions">
+				<div class="photos-picker__actions__buttons">
+					<UploadPicker :accept="allowedMimes"
+						:context="uploadContext"
+						:destination="photosLocationFolder"
+						:multiple="true"
+						@uploaded="refreshFiles" />
+					<NcButton type="primary" :disabled="loading || selectedFileIds.length === 0" @click="emitPickedEvent">
+						<template #icon>
+							<ImagePlus v-if="!loading" />
+							<NcLoadingIcon v-if="loading" />
+						</template>
+						{{ t('photos', 'Add to {destination}', { destination }) }}
+					</NcButton>
+				</div>
+				<NcNoteCard v-if="photosLocationFolder.attributes['owner-id'] !== currentUser" type="warning">
+					{{ t('photos', 'The destination folder is owned by {owner}', { owner: photosLocationFolder.attributes['owner-id'] }) }}
+				</NcNoteCard>
+			</div>
 		</template>
 
 		<FilesListViewer class="photos-picker__file-list"
@@ -89,11 +96,12 @@
 
 <script>
 import { UploadPicker } from '@nextcloud/upload'
-import { NcButton, NcDialog, NcLoadingIcon, NcSelect, useIsMobile } from '@nextcloud/vue'
+import { NcButton, NcDialog, NcLoadingIcon, NcSelect, NcNoteCard, useIsMobile } from '@nextcloud/vue'
 import { defineComponent } from 'vue'
 import { mapGetters } from 'vuex'
 
 import moment from '@nextcloud/moment'
+import { getCurrentUser } from '@nextcloud/auth'
 
 import ImagePlus from 'vue-material-design-icons/ImagePlus.vue'
 
@@ -116,6 +124,7 @@ export default defineComponent({
 		NcDialog,
 		NcLoadingIcon,
 		NcSelect,
+		NcNoteCard,
 		UploadPicker,
 	},
 
@@ -176,6 +185,7 @@ export default defineComponent({
 			uploadContext: {
 				route: 'albumpicker',
 			},
+			currentUser: getCurrentUser(),
 		}
 	},
 
@@ -278,6 +288,19 @@ export default defineComponent({
 			display: flex;
 			flex-direction: column;
 			justify-content: center;
+		}
+	}
+
+	&__actions {
+		display: flex;
+		flex-direction: column;
+		flex-grow: 1;
+
+		&__buttons {
+			display: flex;
+			align-items: center;
+			justify-content: end;
+			gap: 16px;
 		}
 	}
 }


### PR DESCRIPTION
Done:
- Block upload to the album DAV endpoint if the current user does not own the photo folder.
- Add warning in Photos picker dialog. An alternative would be to hide the button. But uploads cannot be blocked as they are done directly to the DAV files endpoint, so it is impossible to distinguish from a legitimate upload. 

![Screenshot from 2024-09-25 14-40-42](https://github.com/user-attachments/assets/8b63a7c9-6392-4e88-a616-4db4c9f9d3a5)