### PR TITLE
fix(Places): Use event metadata to compute the place

### DIFF
--- a/lib/DB/Place/PlaceMapper.php
+++ b/lib/DB/Place/PlaceMapper.php
@@ -154,9 +154,4 @@ class PlaceMapper {
 			$rows[0]['meta_value_string']
 		);
 	}
-
-	public function setPlaceForFile(string $place, int $fileId): void {
-		$metadata = $this->filesMetadataManager->getMetadata($fileId, true);
-		$metadata->setString('gps', $place, true);
-	}
 }

--- a/lib/Listener/PlaceMetadataProvider.php
+++ b/lib/Listener/PlaceMetadataProvider.php
@@ -42,7 +42,7 @@ class PlaceMetadataProvider implements IEventListener {
 
 		if ($event instanceof MetadataBackgroundEvent) {
 			$metadata = $event->getMetadata();
-			$place = $this->mediaPlaceManager->getPlaceForFile($event->getNode()->getId());
+			$place = $this->mediaPlaceManager->getPlaceForMetadata($metadata);
 			if ($place !== null) {
 				$metadata->setString('photos-place', $place, true);
 			}

--- a/lib/Service/MediaPlaceManager.php
+++ b/lib/Service/MediaPlaceManager.php
@@ -9,8 +9,8 @@ declare(strict_types=1);
 namespace OCA\Photos\Service;
 
 use OCA\Photos\DB\Place\PlaceMapper;
-use OCP\FilesMetadata\Exceptions\FilesMetadataNotFoundException;
 use OCP\FilesMetadata\IFilesMetadataManager;
+use OCP\FilesMetadata\Model\IFilesMetadata;
 
 class MediaPlaceManager {
 	public function __construct(
@@ -21,22 +21,17 @@ class MediaPlaceManager {
 	}
 
 	public function setPlaceForFile(int $fileId): void {
-		$place = $this->getPlaceForFile($fileId);
+		$metadata = $this->filesMetadataManager->getMetadata($fileId, true);
+		$place = $this->getPlaceForMetadata($metadata);
 
 		if ($place === null) {
 			return;
 		}
 
-		$this->placeMapper->setPlaceForFile($place, $fileId);
+		$metadata->setString('gps', $place, true);
 	}
 
-	public function getPlaceForFile(int $fileId): ?string {
-		try {
-			$metadata = $this->filesMetadataManager->getMetadata($fileId, true);
-		} catch (FilesMetadataNotFoundException) {
-			return null;
-		}
-
+	public function getPlaceForMetadata(IFilesMetadata $metadata): ?string {
 		if (!$this->rgcService->arePlacesEnabled() || !$metadata->hasKey('photos-gps')) {
 			return null;
 		}


### PR DESCRIPTION
When using S3 bucket, all the metadata will be computed in a background job. This means that the GPS info won't be in the DB yet, but it will be in the event's metadata.