### PR TITLE
fix: Set version number to stable and add migration to fix configvalues

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <name>Photos</name>
     <summary>Your memories under your control</summary>
     <description>Your memories under your control</description>
-    <version>4.0.0-dev.1</version>
+    <version>4.0.0</version>
     <licence>agpl</licence>
     <author mail="skjnldsv@protonmail.com">John Molakvoæ</author>
     <namespace>Photos</namespace>

--- a/lib/Controller/AlbumsController.php
+++ b/lib/Controller/AlbumsController.php
@@ -150,8 +150,8 @@ class AlbumsController extends Controller {
 	}
 
 	private function isShared(Node $node): bool {
-		return $node->getStorage()->instanceOfStorage(SharedStorage::class) ||
-			$node->getStorage()->instanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class);
+		return $node->getStorage()->instanceOfStorage(SharedStorage::class)
+			|| $node->getStorage()->instanceOfStorage(\OCA\GroupFolders\Mount\GroupFolderStorage::class);
 	}
 
 	private function scanFolder(Folder $folder, int $depth, bool $shared): bool {

--- a/lib/Listener/ExifMetadataProvider.php
+++ b/lib/Listener/ExifMetadataProvider.php
@@ -82,14 +82,14 @@ class ExifMetadataProvider implements IEventListener {
 		}
 
 		if (
-			$rawExifData &&
-			array_key_exists('GPS', $rawExifData)
+			$rawExifData
+			&& array_key_exists('GPS', $rawExifData)
 		) {
 			$gps = [];
 
 			if (
-				array_key_exists('GPSLatitude', $rawExifData['GPS']) && array_key_exists('GPSLatitudeRef', $rawExifData['GPS']) &&
-				array_key_exists('GPSLongitude', $rawExifData['GPS']) && array_key_exists('GPSLongitudeRef', $rawExifData['GPS'])
+				array_key_exists('GPSLatitude', $rawExifData['GPS']) && array_key_exists('GPSLatitudeRef', $rawExifData['GPS'])
+				&& array_key_exists('GPSLongitude', $rawExifData['GPS']) && array_key_exists('GPSLongitudeRef', $rawExifData['GPS'])
 			) {
 				$gps['latitude'] = $this->gpsDegreesToDecimal($rawExifData['GPS']['GPSLatitude'], $rawExifData['GPS']['GPSLatitudeRef']);
 				$gps['longitude'] = $this->gpsDegreesToDecimal($rawExifData['GPS']['GPSLongitude'], $rawExifData['GPS']['GPSLongitudeRef']);

--- a/lib/Migration/Version40000Date20250624085327.php
+++ b/lib/Migration/Version40000Date20250624085327.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Photos\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use Psr\Log\LoggerInterface;
+
+use function array_map;
+use function json_decode;
+
+/**
+ * Fix incorrect type in photosLocation and photosSourceFolders
+ */
+class Version40000Date20250624085327 extends SimpleMigrationStep {
+	public function __construct(
+		private IDBConnection $db,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 */
+	public function postSchemaChange(IOutput $output, Closure $schemaClosure, array $options): void {
+		/* Convert photosLocation from array to string if needed */
+		$select = $this->db->getQueryBuilder();
+		$select->select('userid', 'configvalue')
+			->from('preferences')
+			->where($select->expr()->eq('appid', $select->expr()->literal('photos')))
+			->andWhere($select->expr()->eq('configkey', $select->expr()->literal('photosLocation')))
+			->andWhere($select->expr()->like('configvalue', $select->expr()->literal('[%]')));
+
+		$update = $this->db->getQueryBuilder();
+		$update->update('preferences')
+			->set('configvalue', $update->createParameter('newvalue'))
+			->where($update->expr()->eq('appid', $update->expr()->literal('photos')))
+			->andWhere($update->expr()->eq('configkey', $update->expr()->literal('photosLocation')))
+			->andWhere($update->expr()->eq('userid', $update->createParameter('userid')));
+
+		$result = $select->executeQuery();
+		while (($row = $result->fetch()) !== false) {
+			$update->setParameter('userid', $row['userid'], IQueryBuilder::PARAM_STR);
+			try {
+				$newvalue = json_decode($row['configvalue'], flags:JSON_THROW_ON_ERROR)[0];
+			} catch (\Throwable $t) {
+				$this->logger->error('Could not fix configvalue for photosLocation', ['exception' => $t]);
+				continue;
+			}
+			$update->setParameter('newvalue', (string)$newvalue, IQueryBuilder::PARAM_STR);
+			$update->executeStatement();
+		}
+		$result->closeCursor();
+
+		/* Convert photosSourceFolders items from array to string if needed */
+		$select = $this->db->getQueryBuilder();
+		$select->select('userid', 'configvalue')
+			->from('preferences')
+			->where($select->expr()->eq('appid', $select->expr()->literal('photos')))
+			->andWhere($select->expr()->eq('configkey', $select->expr()->literal('photosSourceFolders')))
+			->andWhere($select->expr()->like('configvalue', $select->expr()->literal('[%[%]')));
+
+		$update = $this->db->getQueryBuilder();
+		$update->update('preferences')
+			->set('configvalue', $update->createParameter('newvalue'))
+			->where($update->expr()->eq('appid', $update->expr()->literal('photos')))
+			->andWhere($update->expr()->eq('configkey', $update->expr()->literal('photosSourceFolders')))
+			->andWhere($update->expr()->eq('userid', $update->createParameter('userid')));
+
+		$result = $select->executeQuery();
+		while (($row = $result->fetch()) !== false) {
+			$update->setParameter('userid', $row['userid'], IQueryBuilder::PARAM_STR);
+			try {
+				$newvalue = json_encode(
+					array_map(
+						fn (array|string $item): string => (is_array($item) ? (string)reset($item) : $item),
+						json_decode($row['configvalue'], flags:JSON_THROW_ON_ERROR),
+					),
+					flags:JSON_THROW_ON_ERROR
+				);
+			} catch (\Throwable $t) {
+				$this->logger->error('Could not fix configvalue for photosSourceFolders', ['exception' => $t]);
+				continue;
+			}
+			$update->setParameter('newvalue', (string)$newvalue, IQueryBuilder::PARAM_STR);
+			$update->executeStatement();
+		}
+		$result->closeCursor();
+	}
+}


### PR DESCRIPTION
- Fix #3025 

Previous version of nextcloud/dialogs resulted in array instead of string in some config values. Add a migration to fix those.
The bug itself was already fix when `nextcloud/dialogs` was upgraded to 6.3.0. This fixes the database values for users which used the broken version.

The migration is not needed on master as it’s a one-time fix and Nextcloud always upgrade to latest minor first before upgrade to a new major.