### PR TITLE
fix(AutomaticPlaceMapperJob): Do not fail when there are no users

### DIFF
--- a/lib/Jobs/AutomaticPlaceMapperJob.php
+++ b/lib/Jobs/AutomaticPlaceMapperJob.php
@@ -42,6 +42,10 @@ class AutomaticPlaceMapperJob extends TimedJob {
 		}
 
 		$users = $this->userManager->search('');
+		if ($users === []) {
+			return;
+		}
+
 		$lastMappedUser = $this->config->getAppValue(Application::APP_ID, 'lastPlaceMappedUser', '');
 
 		if ($lastMappedUser === '') {


### PR DESCRIPTION
With https://github.com/nextcloud/server/pull/53212 it is possible that this job runs when there are no users on the instance.
Then `$lastMappedUser = $users[array_key_first($users)]->getUID();` will produce the following crash:
```
{
  "Exception": "Error",
  "Message": "Call to a member function getUID() on null",
  "Code": 0,
  "Trace": [
    {
      "file": "/nix/store/n1lzxp2m7ffvqnzmbw4zr9bibx4mf5nq-nextcloud-32.0.0/lib/public/BackgroundJob/Job.php",
      "line": 61,
      "function": "run",
      "class": "OCA\\Photos\\Jobs\\AutomaticPlaceMapperJob",
      "type": "->",
      "args": [
        null
      ]
    },
    {
      "file": "/nix/store/n1lzxp2m7ffvqnzmbw4zr9bibx4mf5nq-nextcloud-32.0.0/lib/public/BackgroundJob/TimedJob.php",
      "line": 97,
      "function": "start",
      "class": "OCP\\BackgroundJob\\Job",
      "type": "->",
      "args": [
        {
          "__class__": "OC\\BackgroundJob\\JobList"
        }
      ]
    },
    {
      "file": "/nix/store/n1lzxp2m7ffvqnzmbw4zr9bibx4mf5nq-nextcloud-32.0.0/lib/public/BackgroundJob/TimedJob.php",
      "line": 84,
      "function": "start",
      "class": "OCP\\BackgroundJob\\TimedJob",
      "type": "->",
      "args": [
        {
          "__class__": "OC\\BackgroundJob\\JobList"
        }
      ]
    },
    {
      "file": "/nix/store/n1lzxp2m7ffvqnzmbw4zr9bibx4mf5nq-nextcloud-32.0.0/cron.php",
      "line": 175,
      "function": "execute",
      "class": "OCP\\BackgroundJob\\TimedJob",
      "type": "->",
      "args": [
        {
          "__class__": "OC\\BackgroundJob\\JobList"
        }
      ]
    }
  ],
  "File": "/nix/store/n1lzxp2m7ffvqnzmbw4zr9bibx4mf5nq-nextcloud-32.0.0/apps/photos/lib/Jobs/AutomaticPlaceMapperJob.php",
  "Line": 48,
  "message": "Error while running background job OCA\\Photos\\Jobs\\AutomaticPlaceMapperJob (id: 12, arguments: null)",
  "exception": {},
  "CustomMessage": "Error while running background job OCA\\Photos\\Jobs\\AutomaticPlaceMapperJob (id: 12, arguments: null)"
}
```

Backports are not necessary, since this can only occur on Nextcloud 32+