### PR TITLE
fix(Album): Stop replacing navigation button

### DIFF
--- a/src/components/HeaderNavigation.vue
+++ b/src/components/HeaderNavigation.vue
@@ -83,7 +83,6 @@ export default {
 	computed: {
 		isRoot() {
 			const isRoot = this.path === '/'
-			this.toggleNavigationButton(!isRoot)
 			return isRoot
 		},
 
@@ -102,14 +101,6 @@ export default {
 
 		refresh() {
 			this.$emit('refresh')
-		},
-
-		toggleNavigationButton(hide) {
-			// Hide the navigation toggle if the back button is shown
-			const navigationToggle = document.querySelector('button.app-navigation-toggle') as HTMLElement
-			if (navigationToggle !== null && hide) {
-				navigationToggle.style.display = 'none'
-			}
 		},
 
 		t,
@@ -132,12 +123,6 @@ export default {
 	// Align with app navigation toggle
 	padding-block: var(--app-navigation-padding);
 	background: var(--color-main-background);
-
-	&__back {
-		// Replaces the app navigation button
-		position: absolute !important;
-		inset-inline-start: var(--app-navigation-padding);
-	}
 
 	&__title {
 		max-width: 45%;
@@ -186,5 +171,4 @@ export default {
 		}
 	}
 }
-
 </style>


### PR DESCRIPTION
This does not make sense, and work badly on mobile.

Issues were:
- User could not toggle the sidebar in the album content view
- User could no got back from the album content view with the sidebar open
- The sidebar button was not re-enabled when leaving the album content view

| View | Before | After |
|--------|--------|--------|
| Sidebar open | <img width="526" height="340" alt="image" src="https://github.com/user-attachments/assets/eb0bd808-d2fa-48ce-a01b-2c52d4974d53" /> | <img width="526" height="340" alt="image" src="https://github.com/user-attachments/assets/5b0a04c9-db21-4967-bd83-bfba59678d76" /> |
| Sidebar closed | <img width="526" height="340" alt="image" src="https://github.com/user-attachments/assets/88c5d186-de7e-4a03-89cc-fd3f1db0c85f" /> | <img width="526" height="340" alt="image" src="https://github.com/user-attachments/assets/e9d06cb3-1001-4505-96fc-b244bf2be279" /> |