### PR TITLE
fix: Disable ReverseGeoCoderService when the server has no internet

### DIFF
--- a/lib/Service/ReverseGeoCoderService.php
+++ b/lib/Service/ReverseGeoCoderService.php
@@ -68,6 +68,10 @@ class ReverseGeoCoderService {
 	}
 
 	public function arePlacesEnabled(): bool {
+		if (!$this->config->getSystemValueBool('has_internet_connection', true)) {
+			/* This feature cannot work without internet access */
+			return false;
+		}
 		return ($this->config->getAppValue(Application::APP_ID, self::CONFIG_DISABLE_PLACES, '0') !== '1');
 	}
 


### PR DESCRIPTION
This application attempts to download `https://download.nextcloud.com/server/apps/photos/cities1000.zip` even when `has_internet_connection` is set to `false`. This PR fixes that by disabling the related feature in this case.