### PR TITLE
perf: Use distributed cache for no media paths

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -69,7 +69,7 @@ class PageController extends Controller {
 		$this->userSession = $userSession;
 		$this->rootFolder = $rootFolder;
 		$this->cacheFactory = $cacheFactory;
-		$this->nomediaPathsCache = $this->cacheFactory->createLocal('photos:nomedia-paths');
+		$this->nomediaPathsCache = $this->cacheFactory->createDistributed('photos:nomedia-paths');
 		$this->l10n = $l10n;
 	}
 


### PR DESCRIPTION
Local cache is not ideal as it is in most cases with APCu limited in since and on systems with lots of users and with load balanced webserver nodes it is not likely that this cache is hit. 

Moving to a distributed one should make sure this is more likely to have a cache hit on big instances and overhead to the distributed should be ok with a page load request doing one cache check