### PR TITLE
[stable32] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -132,12 +132,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "83cf79e2922fe1c969adeeac8dbb10e173a8d781"
+                "reference": "aa9d5a01d17cb9c19ca32532e08e999d693679fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/83cf79e2922fe1c969adeeac8dbb10e173a8d781",
-                "reference": "83cf79e2922fe1c969adeeac8dbb10e173a8d781",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/aa9d5a01d17cb9c19ca32532e08e999d693679fc",
+                "reference": "aa9d5a01d17cb9c19ca32532e08e999d693679fc",
                 "shasum": ""
             },
             "require": {
@@ -172,7 +172,7 @@
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
                 "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2026-02-06T01:05:41+00:00"
+            "time": "2026-02-24T01:08:25+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency