### PR TITLE
fix(metadata): exif_read_data() supports JPEG/TIFF

### DIFF
--- a/lib/Listener/ExifMetadataProvider.php
+++ b/lib/Listener/ExifMetadataProvider.php
@@ -79,15 +79,18 @@ class ExifMetadataProvider implements IEventListener {
 			// This is to trigger this condition: https://github.com/php/php-src/blob/d64aa6f646a7b5e58359dc79479860164239580a/main/streams/streams.c#L710
 			// But I don't understand yet why 1 as a special meaning.
 			$oldBufferSize = stream_set_chunk_size($fileDescriptor, 1);
-			if ($node->getMimeType() == 'image/webp') {
+			if ($node->getMimeType() === 'image/webp') {
 				$rawExifData = $this->getExifFromWebP($fileDescriptor);
-			} else {
+			}
+
+			$exifSupportedMimes = ['image/jpeg', 'image/tiff'];
+			if (in_array($node->getMimeType(), $exifSupportedMimes, true)) {
 				$rawExifData = @exif_read_data($fileDescriptor, 'EXIF, GPS', true);
 			}
 
 			// We then revert the change after having read the exif data.
 			stream_set_chunk_size($fileDescriptor, $oldBufferSize);
-		} catch (\Exception $ex) {
+		} catch (\Throwable $ex) {
 			$this->logger->info('Failed to extract metadata for ' . $node->getId(), ['exception' => $ex]);
 		}
 


### PR DESCRIPTION
Fix errors during `occ files:scan --generate-metadata`:

```
File    /user/files/images/lfile.png
Error during scan: exif_read_data(): File not supported
#0 /var/www/nextcloud/apps/files/lib/Command/Scan.php(290): OCA\Files\Command\Scan->exceptionErrorHandler()
#1 [internal function]: OCA\Files\Command\Scan->{closure:OCA\Files\Command\Scan::initTools():289}()
#2 /var/www/nextcloud/apps/photos/lib/Listener/ExifMetadataProvider.php(74): exif_read_data()
```