### PR TITLE
fix: Adjust to API change of "getDavPermissions" in Nextcloud 34

### DIFF
--- a/lib/Sabre/PropFindPlugin.php
+++ b/lib/Sabre/PropFindPlugin.php
@@ -92,7 +92,7 @@ class PropFindPlugin extends ServerPlugin {
 			$propFind->handle(self::FAVORITE_PROPERTYNAME, fn (): int => $node->isFavorite() ? 1 : 0);
 			$propFind->handle(FilesPlugin::HAS_PREVIEW_PROPERTYNAME, fn () => json_encode($this->previewManager->isAvailable($fileInfo)));
 			$propFind->handle(FilesPlugin::PERMISSIONS_PROPERTYNAME, function () use ($node): string {
-				$permissions = DavUtil::getDavPermissions($node->getFileInfo());
+				$permissions = DavUtil::getDavPermissions($node->getFileInfo(), $node->getFileInfo()->getParent());
 				$filteredPermissions = str_replace('R', '', $permissions);
 
 				if ($node instanceof PublicAlbumPhoto) {


### PR DESCRIPTION
[Since Nextcloud 34 `DavUtil::getDavPermissions` requires the parent of the node as its second parameter](https://github.com/nextcloud/server/commit/c08592de289131e6336f52917428185eaefb44bf#diff-2ff61de201f8d968b8e5c485471d464782cd095c058aaa496bfb1207f7334dd7).

As this is an API breaking change [in the backport to Nextcloud 33 the second parameter was made optional](https://github.com/nextcloud/server/pull/59241#issuecomment-4142802625). It is unclear yet whether this will be applied too in Nextcloud 34 (in which case this pull request would be unneeded) or not :thinking: 