### PR TITLE
chore: bump app version to 7.0.0-dev.1 and fix the db migration

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@
     <name>Photos</name>
     <summary>Your memories under your control</summary>
     <description>Your memories under your control</description>
-    <version>7.0.0-dev.0</version>
+    <version>7.0.0-dev.1</version>
     <licence>agpl</licence>
     <author mail="skjnldsv@protonmail.com">John Molakvoæ</author>
     <namespace>Photos</namespace>


### PR DESCRIPTION
Force NC's `app:upgrade` to pick up the new schema migrations and background-job registrations from the perf-index / search-indexed / hls-transcoding branches. The version bump is the trigger that makes `occ app:enable photos` (and `occ upgrade`) re-run the migration loader for this app.