### PR TITLE
fix: Fix "Failed to fetch collection list" when trying to open albums

### DIFF
--- a/lib/Sabre/PropFindPlugin.php
+++ b/lib/Sabre/PropFindPlugin.php
@@ -91,8 +91,8 @@ class PropFindPlugin extends ServerPlugin {
 			$propFind->handle(self::FILE_NAME_PROPERTYNAME, fn (): string => $node->getFile()->getName());
 			$propFind->handle(self::FAVORITE_PROPERTYNAME, fn (): int => $node->isFavorite() ? 1 : 0);
 			$propFind->handle(FilesPlugin::HAS_PREVIEW_PROPERTYNAME, fn () => json_encode($this->previewManager->isAvailable($fileInfo)));
-			$propFind->handle(FilesPlugin::PERMISSIONS_PROPERTYNAME, function () use ($node): string {
-				$permissions = DavUtil::getDavPermissions($node->getFileInfo());
+			$propFind->handle(FilesPlugin::PERMISSIONS_PROPERTYNAME, function () use ($node, $fileInfo): string {
+				$permissions = DavUtil::getDavPermissions($fileInfo, $fileInfo->getParent());
 				$filteredPermissions = str_replace('R', '', $permissions);
 
 				if ($node instanceof PublicAlbumPhoto) {


### PR DESCRIPTION
Before | After
-|-
<img width="2552" height="1253" alt="image" src="https://github.com/user-attachments/assets/ab78cff4-264f-4211-82b9-750a4f2ede9e" />|<img width="2552" height="1253" alt="image" src="https://github.com/user-attachments/assets/baea7b9e-4a9b-482a-9c01-969656fb0221" />

Possibly related:
- https://github.com/nextcloud/photos/issues/1398
- https://github.com/nextcloud/photos/issues/1197

---

AI-assisted: GitHub Copilot (Claude Sonnet 4.6)

### Prompt
I’m getting "Failed to fetch collection list" when trying to open albums. These are the errors from the browser console:

```The resource from                                      
“https://nextcloud.local/apps-extra/profiler/css/profiler-toolbar.css” was blocked due to MIME type (“text/html”) mismatch (X-Content-Type-Options: nosniff). Cityscapes        
The resource from “https://nextcloud.local/apps/comments/css/comments-tab.css” was blocked due to MIME type (“text/html”) mismatch (X-Content-Type-Options: nosniff). Cityscapes
The resource from “https://nextcloud.local/apps/files_versions/css/sidebar-tab.css” was blocked due to MIME type (“text/html”) mismatch (X-Content-Type-Options: nosniff).      
Cityscapes                                                                                                                                                                      
Uncaught TypeError: can't access property "Tab", OCA.Files.Sidebar is undefined                                                                                                 
    <anonymous> sidebar.ts:21                                                                                                                                                   
sidebar.ts:21:19                                                                                                                                                                
[ERROR] photos: Error fetching collection files                                                                                                                                 
Object { app: "photos", uid: "admin", level: 0, error: Error }                                                                                                                  
index.mjs:54:17                                                                                                                                                                 
[ERROR] photos: [PublicCollectionContent] Error fetching collection files                                                                                                       
Object { app: "photos", uid: "admin", level: 0, error: Error }                                                                                                                  
index.mjs:54:17                                                                                                                                                                 
XHR                                                                                                                                                                             
PROPFIND                                                                                                                                                                        
https://nextcloud.local/remote.php/dav/photos/admin/albums/Recent/                                                                                                              
[HTTP/2 500  161ms]                                                                                                                                                             
                                                                                                                                                                                
[ERROR] photos: Error fetching collection files                                                                                                                                 
Object { app: "photos", uid: "admin", level: 0, error: Error }                                                                                                                  
index.mjs:54:17                                                                                                                                                                 
[ERROR] photos: [PublicCollectionContent] Error fetching collection files                                                                                                       
Object { app: "photos", uid: "admin", level: 0, error: Error }                                                                                                                  
index.mjs:54:17                                                                                                                                                                 
XHR                                                                                                                                                                             
PROPFIND                                                                                                                                                                        
https://nextcloud.local/remote.php/dav/photos/admin/albums/Cityscapes/                                                                                                          
[HTTP/2 500  131ms]                                                                                                                                                             
                                                                                                                                                                                
[ERROR] photos: Error fetching collection files                                                                                                                                 
Object { app: "photos", uid: "admin", level: 0, error: Error }                                                                                                                  
index.mjs:54:17                                                                                                                                                                 
[ERROR] photos: [PublicCollectionContent] Error fetching collection files                                                                                                       
Object { app: "photos", uid: "admin", level: 0, error: Error }                                                                                                                  
index.mjs:54:17 
```

### Output

```
The fix is clear: getDavPermissions() now requires a second FileInfo $parent argument, but PropFindPlugin.php only passes one. The $fileInfo variable is already available in the
  closure's outer scope.

The PROPFIND now returns HTTP 200 with all photos and their permissions (e.g. GDNVW). The fix works.

  Root cause: OCP\Files\DavUtil::getDavPermissions() was updated to require a second FileInfo $parent argument (used to compute rename permissions), but PropFindPlugin.php was still
  calling it with only one argument.

  Fix: Pass $fileInfo->getParent() as the second argument, reusing the $fileInfo variable already captured in the closure's outer scope.
```