### PR TITLE
Fix timestamp when looking at photos

### DIFF
--- a/lib/Listener/OriginalDateTimeMetadataProvider.php
+++ b/lib/Listener/OriginalDateTimeMetadataProvider.php
@@ -38,7 +38,7 @@ class OriginalDateTimeMetadataProvider implements IEventListener {
 		try {
 			// Note: We do not have the timezone when parsing the date, so the timestamp will be off by X hours.
 			$dateTime = DateTime::createFromFormat($format, $date);
-			if ($dateTime !== false) {
+			if ($dateTime !== false && $dateTime->getTimestamp() > 0) {
 				return $dateTime->getTimestamp();
 			}
 			return false;

--- a/lib/Listener/OriginalDateTimeMetadataProvider.php
+++ b/lib/Listener/OriginalDateTimeMetadataProvider.php
@@ -112,6 +112,9 @@ class OriginalDateTimeMetadataProvider implements IEventListener {
 		}
 
 		// Fallback to the mtime.
-		$metadata->setInt(self::METADATA_KEY, $node->getMTime(), true);
+		$mtime = $node->getMTime();
+		if ($mtime > 0) {
+			$metadata->setInt(self::METADATA_KEY, $mtime, true);
+		}
 	}
 }

--- a/lib/Listener/OriginalDateTimeMetadataProvider.php
+++ b/lib/Listener/OriginalDateTimeMetadataProvider.php
@@ -115,6 +115,9 @@ class OriginalDateTimeMetadataProvider implements IEventListener {
 		$mtime = $node->getMTime();
 		if ($mtime > 0) {
 			$metadata->setInt(self::METADATA_KEY, $mtime, true);
+			return;
 		}
+		
+		$metadata->setInt(self::METADATA_KEY,  $node->getUploadTime(), true);		
 	}
 }


### PR DESCRIPTION
Reject timestamp 0 as it is very unlikely to represent the right time and least to photos being unsorted.

This is especially true for my setup using the S3 from OVH that seem to not return the mtime.


## 🤖 AI (if applicable)

- [X] The content of this PR was partly or fully generated using AI

Fixes: https://github.com/nextcloud/photos/issues/2768