### PR TITLE
fix(timeline): hide create-album label text on mobile

### DIFF
--- a/src/views/TimelineView.vue
+++ b/src/views/TimelineView.vue
@@ -36,7 +36,9 @@
 					:aria-label="createAlbumButtonLabel"
 					data-cy-header-action="create-album"
 					@click="showAlbumCreationForm = true">
-					{{ createAlbumButtonLabel }}
+					<template v-if="!isMobile" #default>
+						{{ createAlbumButtonLabel }}
+					</template>
 					<template #icon>
 						<PlusBoxMultipleOutline />
 					</template>


### PR DESCRIPTION
## Summary
- Hide the "Create new album from filters" button label on mobile, matching sibling header actions.
- Prevents the photos timeline header from overflowing horizontally on narrow viewports.

Fixes #3579

## Test plan
- [ ] On a narrow/mobile viewport, open Photos timeline — Create-album control should show icon without forcing horizontal scroll.
- [ ] On desktop, the full label remains visible.
