### PR TITLE
fix(routes): handle shared root path and clean up route definitions

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -7,85 +7,158 @@
 
 return [
 	'routes' => [
-		['name' => 'api#setUserConfig', 'url' => '/api/v1/config/{key}', 'verb' => 'PUT'],
-		['name' => 'api#serviceWorker', 'url' => '/service-worker.js', 'verb' => 'GET'],
+		// API endpoints used by the Photos frontend
+		[
+			'name' => 'api#setUserConfig',
+			'url' => '/api/v1/config/{key}',
+			'verb' => 'PUT',
+		],
+		[
+			'name' => 'api#serviceWorker',
+			'url' => '/service-worker.js',
+			'verb' => 'GET',
+		],
 
-		['name' => 'page#index', 'url' => '/', 'verb' => 'GET'],
-		['name' => 'page#index', 'url' => '/thisday', 'verb' => 'GET', 'postfix' => 'thisday'],
-		['name' => 'page#index', 'url' => '/photos', 'verb' => 'GET', 'postfix' => 'photos'],
-		['name' => 'page#index', 'url' => '/videos', 'verb' => 'GET', 'postfix' => 'videos'],
-		['name' => 'page#index', 'url' => '/favorites', 'verb' => 'GET', 'postfix' => 'favorites'],
-		['name' => 'page#index', 'url' => '/albums/{path}', 'verb' => 'GET', 'postfix' => 'albums',
+		// Frontend entry points
+		[
+			'name' => 'page#index',
+			'url' => '/',
+			'verb' => 'GET',
+		],
+		[
+			'name' => 'page#index',
+			'url' => '/thisday',
+			'verb' => 'GET',
+			'postfix' => 'thisday',
+		],
+		[
+			'name' => 'page#index',
+			'url' => '/photos',
+			'verb' => 'GET',
+			'postfix' => 'photos',
+		],
+		[
+			'name' => 'page#index',
+			'url' => '/videos',
+			'verb' => 'GET',
+			'postfix' => 'videos',
+		],
+		[
+			'name' => 'page#index',
+			'url' => '/favorites',
+			'verb' => 'GET',
+			'postfix' => 'favorites',
+		],
+
+		// Collection and folder views
+		[
+			'name' => 'page#index',
+			'url' => '/albums/{path}',
+			'verb' => 'GET',
+			'postfix' => 'albums',
 			'requirements' => [
 				'path' => '.*',
 			],
 			'defaults' => [
 				'path' => '',
-			]
+			],
 		],
-		['name' => 'page#index', 'url' => '/sharedalbums/{path}', 'verb' => 'GET', 'postfix' => 'sharedalbums',
+		[
+			'name' => 'page#index',
+			'url' => '/sharedalbums/{path}',
+			'verb' => 'GET',
+			'postfix' => 'sharedalbums',
 			'requirements' => [
 				'path' => '.*',
 			],
 			'defaults' => [
 				'path' => '',
-			]
+			],
 		],
-		['name' => 'page#index', 'url' => '/places/{path}', 'verb' => 'GET', 'postfix' => 'places',
+		[
+			'name' => 'page#index',
+			'url' => '/places/{path}',
+			'verb' => 'GET',
+			'postfix' => 'places',
 			'requirements' => [
 				'path' => '.*',
 			],
 			'defaults' => [
 				'path' => '',
-			]
+			],
 		],
-		[ 'name' => 'publicAlbum#get', 'url' => '/public/{token}', 'verb' => 'GET',
+		[
+			'name' => 'page#index',
+			'url' => '/folders/{path}',
+			'verb' => 'GET',
+			'postfix' => 'folders',
+			'requirements' => [
+				'path' => '.*',
+			],
+			'defaults' => [
+				'path' => '',
+			],
+		],
+		[
+			'name' => 'page#index',
+			'url' => '/faces/{path}',
+			'verb' => 'GET',
+			'postfix' => 'faces',
+			'requirements' => [
+				'path' => '.*',
+			],
+			'defaults' => [
+				'path' => '',
+			],
+		],
+		[
+			'name' => 'page#index',
+			'url' => '/shared/{path}',
+			'verb' => 'GET',
+			'postfix' => 'shared',
+			'requirements' => [
+				'path' => '.*',
+			],
+			'defaults' => [
+				'path' => '',
+			],
+		],
+		[
+			'name' => 'page#index',
+			'url' => '/tags/{path}',
+			'verb' => 'GET',
+			'postfix' => 'tags',
+			'requirements' => [
+				'path' => '.*',
+			],
+			'defaults' => [
+				'path' => '',
+			],
+		],
+		[
+			'name' => 'page#index',
+			'url' => '/categories/{path}',
+			'verb' => 'GET',
+			'postfix' => 'categories',
+			'requirements' => [
+				'path' => '.*',
+			],
+			'defaults' => [
+				'path' => '',
+			],
+		],
+
+		// Public album view
+		[
+			'name' => 'publicAlbum#get',
+			'url' => '/public/{token}',
+			'verb' => 'GET',
 			'requirements' => [
 				'token' => '.*',
 			],
 		],
-		['name' => 'page#index', 'url' => '/folders/{path}', 'verb' => 'GET', 'postfix' => 'folders',
-			'requirements' => [
-				'path' => '.*',
-			],
-			'defaults' => [
-				'path' => '',
-			]
-		],
-		['name' => 'page#index', 'url' => '/faces/{path}', 'verb' => 'GET', 'postfix' => 'faces',
-			'requirements' => [
-				'path' => '.*',
-			],
-			'defaults' => [
-				'path' => '',
-			]
-		],
-		['name' => 'page#index', 'url' => '/shared/{path}', 'verb' => 'GET', 'postfix' => 'shared',
-			'requirements' => [
-				'path' => '.*',
-			],
-			'defaults' => [
-				'path' => '',
-			]
-		],
-		['name' => 'page#index', 'url' => '/tags/{path}', 'verb' => 'GET', 'postfix' => 'tags',
-			'requirements' => [
-				'path' => '.*',
-			],
-			'defaults' => [
-				'path' => '',
-			]
-		],
-		['name' => 'page#index', 'url' => '/categories/{path}', 'verb' => 'GET', 'postfix' => 'categories',
-			'requirements' => [
-				'path' => '.*',
-			],
-			'defaults' => [
-				'path' => '',
-			]
-		],
 
-		// apis
+		// Data APIs
 		[
 			'name' => 'albums#myAlbums',
 			'url' => '/api/v1/albums/{path}',
@@ -109,22 +182,22 @@ return [
 			],
 		],
 
+		// Preview APIs
 		[
 			'name' => 'preview#index',
 			'url' => '/api/v1/preview/{fileId}',
 			'verb' => 'GET',
 			'requirements' => [
 				'fileId' => '.*',
-			]
+			],
 		],
-
 		[
 			'name' => 'publicPreview#index',
 			'url' => '/api/v1/publicPreview/{fileId}',
 			'verb' => 'GET',
 			'requirements' => [
 				'fileId' => '.*',
-			]
+			],
 		],
-	]
+	],
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -52,14 +52,6 @@ return [
 				'path' => '',
 			]
 		],
-		['name' => 'page#index', 'url' => '/folders/{path}', 'verb' => 'GET', 'postfix' => 'folders',
-			'requirements' => [
-				'path' => '.*',
-			],
-			'defaults' => [
-				'path' => '',
-			]
-		],
 		['name' => 'page#index', 'url' => '/faces/{path}', 'verb' => 'GET', 'postfix' => 'faces',
 			'requirements' => [
 				'path' => '.*',
@@ -72,6 +64,9 @@ return [
 			'requirements' => [
 				'path' => '.*',
 			],
+			'defaults' => [
+				'path' => '',
+			]
 		],
 		['name' => 'page#index', 'url' => '/tags/{path}', 'verb' => 'GET', 'postfix' => 'tags',
 			'requirements' => [


### PR DESCRIPTION
## Summary

Commit 1:
- Remove the duplicate `/folders/{path}` route definition.
- Make sure the `/shared` root route resolve correctly by always providing an empty default path.

Commit 2:
- Normalize route formatting, trailing commas, and spacing.
- Group route definitions with clearer section comments.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
