### PR TITLE
fix(album): calculate date range end against latest date

### DIFF
--- a/lib/Sabre/Album/AlbumRootBase.php
+++ b/lib/Sabre/Album/AlbumRootBase.php
@@ -174,7 +174,7 @@ abstract class AlbumRootBase implements ICollection, ICopyTarget {
 				$earliestDate = $childCreationDate;
 			}
 
-			if ($childCreationDate > $earliestDate || $latestDate === null) {
+			if ($childCreationDate > $latestDate || $latestDate === null) {
 				$latestDate = $childCreationDate;
 			}
 		}


### PR DESCRIPTION
`getDateRange()` compared each file timestamp against the earliest date instead of the latest date, which could produce an incorrect album date range (depending on the dates and exact ordering).

One additional consideration (for follow-up): The frontend album date label is based on the file node’s mtime, not the photo’s original capture date metadata. `DateRangeFilter` uses the original-date metadata for smart-album filtering, which is EXIF when available.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
