### PR TITLE
fix(album): avoid refetching empty album file lists

### DIFF
--- a/lib/Album/AlbumWithFiles.php
+++ b/lib/Album/AlbumWithFiles.php
@@ -12,8 +12,8 @@ class AlbumWithFiles {
 	public function __construct(
 		private readonly AlbumInfo $info,
 		private readonly AlbumMapper $albumMapper,
-		/** @var AlbumFile[] */
-		private array $files = [],
+		/** @var AlbumFile[]|null */
+		private ?array $files = null,
 	) {
 	}
 
@@ -25,21 +25,16 @@ class AlbumWithFiles {
 	 * @return AlbumFile[]
 	 */
 	public function getFiles(): array {
-		if (empty($this->files)) {
-			$this->files = $this->fetchFiles();
-		}
-		return $this->files;
+		return $this->files ??= $this->fetchFiles();
 	}
 
 	/**
 	 * @return AlbumFile[]
 	 */
 	public function addFile(AlbumFile $file): array {
-		if (empty($this->files)) {
-			$this->files = $this->fetchFiles();
-		}
+		$this->files ??= $this->fetchFiles();
 
-		array_push($this->files, $file);
+		$this->files[] = $file;
 		return $this->files;
 	}
 


### PR DESCRIPTION
Avoid refetching album files when an album has been loaded and contains no files.

Reduces redundant work during repeated DAV property access, especially for empty albums and smart albums whose filters currently match no files.

Changes:

- Use `null` to represent an unloaded file list; preserve `[]` as a valid loaded-and-empty result.
- Avoid repeated database queries and filter evaluation for empty albums.
- Preserve support for preloaded file lists, including explicitly preloaded empty lists.
- Drop unnecessary `array_push`: use array append syntax.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
