### PR TITLE
perf(album): optimize duplicate file filtering

### DIFF
--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -186,11 +186,17 @@ class AlbumMapper {
 			}
 		}
 
-		$fileIds = array_map(fn ($file) => $file->getFileId(), $files);
+		$fileIds = array_fill_keys(
+			array_map(
+				static fn (AlbumFile $file): int => $file->getFileId(),
+				$files,
+			),
+			true,
+		);
 
 		$smartAlbumFiles = array_filter(
 			$this->filtersManager->getFilesBasedOnFilters($userId, $filters),
-			fn ($file) => array_search($file->getFileId(), $fileIds) === false,
+			static fn (AlbumFile $file): bool => !isset($fileIds[$file->getFileId()]),
 		);
 
 		return [...$files, ...$smartAlbumFiles];
@@ -527,11 +533,18 @@ class AlbumMapper {
 		$result = [];
 		foreach ($albumsById as $id => $album) {
 			$filesByAlbum[$id] ??= [];
-			$fileIds = array_map(fn ($file) => $file->getFileId(), $filesByAlbum[$id]);
+
+			$fileIds = array_fill_keys(
+				array_map(
+					static fn (AlbumFile $file): int => $file->getFileId(),
+					$filesByAlbum[$id],
+				),
+				true,
+			);
 
 			$smartAlbumFiles = array_filter(
 				$this->filtersManager->getFilesBasedOnFilters($album->getUserId(), $album->getDecodedFilters()),
-				fn ($file) => array_search($file->getFileId(), $fileIds) === false,
+				static fn (AlbumFile $file): bool => !isset($fileIds[$file->getFileId()]),
 			);
 
 			$result[] = new AlbumWithFiles($album, $this, [...$filesByAlbum[$id], ...$smartAlbumFiles]);


### PR DESCRIPTION
Optimize duplicate filtering step used when combining manually added album files with smart-album results.

Changes:

- Build an associative ID set from the existing album files.
- Replace per-file `array_search()` scans with average O(1) lookups via `isset()`.
- Apply the optimization to both regular and shared album file merging.

## Impact

Reduces the duplicate-filtering step from approximately O(n × m) to O(n + m) by avoiding a full scan of the existing file-ID list for each smart-album result. The per-file `array_search()` is replaced with an average O(1) associative-array lookup via `isset()` (where `n` is the number of existing album files and `m` is the number of smart-album results).

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
