### PR TITLE
fix(album): roll back failed database transactions

### DIFF
--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -164,10 +164,10 @@ class AlbumMapper {
 			$this->connection->commit();
 		} catch (\Throwable $e) {
 			$this->connection->rollBack();
- 			throw $e;
- 		}
- 	}
-			
+			throw $e;
+		}
+	}
+
 	/**
 	 * @return AlbumFile[]
 	 */
@@ -453,6 +453,7 @@ class AlbumMapper {
 		} catch (\Throwable $e) {
 			$this->connection->rollBack();
 			throw $e;
+		}
 	}
 
 	/**

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -145,24 +145,29 @@ class AlbumMapper {
 	public function delete(int $id): void {
 		$this->connection->beginTransaction();
 
-		$query = $this->connection->getQueryBuilder();
-		$query->delete('photos_albums')
-			->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$query->executeStatement();
+		try {
+			$query = $this->connection->getQueryBuilder();
+			$query->delete('photos_albums_files')
+				->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+			$query->executeStatement();
 
-		$query = $this->connection->getQueryBuilder();
-		$query->delete('photos_albums_files')
-			->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$query->executeStatement();
+			$query = $this->connection->getQueryBuilder();
+			$query->delete('photos_albums_collabs')
+				->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+			$query->executeStatement();
 
-		$query = $this->connection->getQueryBuilder();
-		$query->delete('photos_albums_collabs')
-			->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
-		$query->executeStatement();
+			$query = $this->connection->getQueryBuilder();
+			$query->delete('photos_albums')
+				->where($query->expr()->eq('album_id', $query->createNamedParameter($id, IQueryBuilder::PARAM_INT)));
+			$query->executeStatement();
 
-		$this->connection->commit();
-	}
-
+			$this->connection->commit();
+		} catch (\Throwable $e) {
+			$this->connection->rollBack();
+ 			throw $e;
+ 		}
+ 	}
+			
 	/**
 	 * @return AlbumFile[]
 	 */
@@ -401,49 +406,53 @@ class AlbumMapper {
 
 		$this->connection->beginTransaction();
 
-		foreach ($collaboratorsToAdd as $collaborator) {
-			switch ($collaborator['type']) {
-				case self::TYPE_USER:
-					if (is_null($this->userManager->get($collaborator['id']))) {
-						throw new \Exception('Unknown collaborator: ' . $collaborator['id']);
-					}
-					break;
-				case self::TYPE_GROUP:
-					if (is_null($this->groupManager->get($collaborator['id']))) {
-						throw new \Exception('Unknown collaborator: ' . $collaborator['id']);
-					}
-					break;
-				case self::TYPE_LINK:
-					$collaborator['id'] = $this->random->generate(32, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
-					break;
-				default:
-					throw new \Exception('Invalid collaborator type: ' . $collaborator['type']);
+		try {
+			foreach ($collaboratorsToAdd as $collaborator) {
+				switch ($collaborator['type']) {
+					case self::TYPE_USER:
+						if (is_null($this->userManager->get($collaborator['id']))) {
+							throw new \Exception('Unknown collaborator: ' . $collaborator['id']);
+						}
+						break;
+					case self::TYPE_GROUP:
+						if (is_null($this->groupManager->get($collaborator['id']))) {
+							throw new \Exception('Unknown collaborator: ' . $collaborator['id']);
+						}
+						break;
+					case self::TYPE_LINK:
+						$collaborator['id'] = $this->random->generate(32, ISecureRandom::CHAR_UPPER . ISecureRandom::CHAR_LOWER . ISecureRandom::CHAR_DIGITS);
+						break;
+					default:
+						throw new \Exception('Invalid collaborator type: ' . $collaborator['type']);
+				}
+
+				$query = $this->connection->getQueryBuilder();
+				$query->insert('photos_albums_collabs')
+					->setValue('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT))
+					->setValue('collaborator_id', $query->createNamedParameter($collaborator['id']))
+					->setValue('collaborator_type', $query->createNamedParameter($collaborator['type'], IQueryBuilder::PARAM_INT))
+					->executeStatement();
 			}
 
-			$query = $this->connection->getQueryBuilder();
-			$query->insert('photos_albums_collabs')
-				->setValue('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT))
-				->setValue('collaborator_id', $query->createNamedParameter($collaborator['id']))
-				->setValue('collaborator_type', $query->createNamedParameter($collaborator['type'], IQueryBuilder::PARAM_INT))
-				->executeStatement();
-		}
-
-		foreach ($collaboratorsToRemove as $collaborator) {
-			switch ($collaborator['type']) {
-				case self::TYPE_USER:
-					$this->deleteUserFromAlbumCollaboratorsList($collaborator['id'], $albumId);
-					break;
-				default:
-					$query = $this->connection->getQueryBuilder();
-					$query->delete('photos_albums_collabs')
-						->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
-						->andWhere($query->expr()->eq('collaborator_id', $query->createNamedParameter($collaborator['id'])))
-						->andWhere($query->expr()->eq('collaborator_type', $query->createNamedParameter($collaborator['type'], IQueryBuilder::PARAM_INT)))
-						->executeStatement();
+			foreach ($collaboratorsToRemove as $collaborator) {
+				switch ($collaborator['type']) {
+					case self::TYPE_USER:
+						$this->deleteUserFromAlbumCollaboratorsList($collaborator['id'], $albumId);
+						break;
+					default:
+						$query = $this->connection->getQueryBuilder();
+						$query->delete('photos_albums_collabs')
+							->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
+							->andWhere($query->expr()->eq('collaborator_id', $query->createNamedParameter($collaborator['id'])))
+							->andWhere($query->expr()->eq('collaborator_type', $query->createNamedParameter($collaborator['type'], IQueryBuilder::PARAM_INT)))
+							->executeStatement();
+				}
 			}
-		}
 
-		$this->connection->commit();
+			$this->connection->commit();
+		} catch (\Throwable $e) {
+			$this->connection->rollBack();
+			throw $e;
 	}
 
 	/**


### PR DESCRIPTION
Ensure album database transactions are rolled back when an exception occurs during multi-step operations.

Prevents partial collaborator updates or album deletions when a later database operation fails.

- Roll back the transaction and rethrow the original exception when `setCollaborators()` fails.
- Apply the same transaction-safety pattern to `delete()`.
- Catch `\Throwable` so both exceptions and PHP errors cannot leave a transaction open.
- Preserve the existing commit behavior when all operations complete successfully.

Since this was a tiny fix didn't think bother to use the `TTransactional` helper.


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
