### PR TITLE
fix(metadata): listener ordering and remote video processing

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -74,9 +74,9 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(AddContentSecurityPolicyEvent::class, CSPListener::class);
 
 		// Metadata
-		$context->registerEventListener(MetadataLiveEvent::class, ExifMetadataProvider::class);
-		$context->registerEventListener(MetadataBackgroundEvent::class, ExifMetadataProvider::class);
-		// SizeMetadataProvider optionally depends on ExifMetadataProvider, so it has to be registered afterwards
+		$context->registerEventListener(MetadataLiveEvent::class, ExifMetadataProvider::class, 10);
+		$context->registerEventListener(MetadataBackgroundEvent::class, ExifMetadataProvider::class, 10);
+		// SizeMetadataProvider depends on ExifMetadataProvider, which is why it's given a higher priority (above)
 		$context->registerEventListener(MetadataLiveEvent::class, SizeMetadataProvider::class);
 		$context->registerEventListener(MetadataBackgroundEvent::class, SizeMetadataProvider::class);
 		$context->registerEventListener(MetadataLiveEvent::class, OriginalDateTimeMetadataProvider::class);

--- a/lib/Listener/OriginalDateTimeMetadataProvider.php
+++ b/lib/Listener/OriginalDateTimeMetadataProvider.php
@@ -68,14 +68,25 @@ class OriginalDateTimeMetadataProvider implements IEventListener {
 			return;
 		}
 
-		// We need the file content to extract the EXIF data.
-		// This can be slow for remote storage, so we do it in a background job.
-		if (!$node->getStorage()->isLocal() && $event instanceof MetadataLiveEvent) {
-			$event->requestBackgroundJob();
+		$mimeType = $node->getMimeType();
+
+		if (
+			!in_array($mimeType, Application::IMAGE_MIMES, true)
+			&& !in_array($mimeType, Application::VIDEO_MIMES, true)
+		) {
 			return;
 		}
 
-		if (!in_array($node->getMimeType(), Application::IMAGE_MIMES) && !in_array($node->getMimeType(), Application::VIDEO_MIMES)) {
+		// We need the file content to extract the EXIF data.
+		// This can be slow for remote storage, so we do it in a background job.
+		// Also, videos do not currently have EXIF metadata extracted, so timestamps
+		// can be handled during the live event.
+		if (
+			in_array($mimeType, Application::IMAGE_MIMES, true)
+			&& !$node->getStorage()->isLocal()
+			&& $event instanceof MetadataLiveEvent
+		) {
+			$event->requestBackgroundJob();
 			return;
 		}
 


### PR DESCRIPTION
- Ensure `ExifMetadataProvider` runs before `SizeMetadataProvider` (mostly a robustness fix that uses the explicit prioritization parameter instead of relying on coded ordering and implementation assumptions).
- Prevent `OriginalDateTimeMetadataProvider` from scheduling unnecessary background jobs for remote videos.
- Filter MIME types before checking remote storage in `OriginalDateTimeMetadataProvider`.

`OriginalDateTimeMetadataProvider` does not extract content metadata from videos. Previously, every supported remote video live event requested a background refresh before MIME-specific processing, even though filename and filesystem timestamp fallbacks can be handled immediately.

The provider now:

- Rejects unsupported MIME types before storage checks.
- Requests background processing only for remote images.
- Processes supported videos during the live event.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
