### PR TITLE
fix: properly handle trashed photos

### DIFF
--- a/lib/Sabre/Album/AlbumPhoto.php
+++ b/lib/Sabre/Album/AlbumPhoto.php
@@ -20,6 +20,11 @@ use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\IFile;
 
 class AlbumPhoto extends CollectionPhoto implements IFile {
+	/**
+	 * Resolved node, or `false` once we know there is none.
+	 */
+	private Node|false|null $node = null;
+
 	public function __construct(
 		private readonly AlbumMapper $albumMapper,
 		private readonly AlbumInfo $album,
@@ -39,14 +44,29 @@ class AlbumPhoto extends CollectionPhoto implements IFile {
 	}
 
 	private function getNode(): Node {
-		$nodes = $this->rootFolder
-			->getUserFolder($this->albumFile->getOwner() ?: $this->album->getUserId())
-			->getById($this->file->getFileId());
-		$node = current($nodes);
-		if ($node) {
-			return $node;
-		} else {
+		if ($this->node === null) {
+			$nodes = $this->rootFolder
+				->getUserFolder($this->albumFile->getOwner() ?: $this->album->getUserId())
+				->getById($this->file->getFileId());
+			$this->node = current($nodes) ?: false;
+		}
+
+		if ($this->node === false) {
 			throw new NotFound('Photo not found for user');
+		}
+
+		return $this->node;
+	}
+
+	/**
+	 * Whether the file behind this entry can still be reached by its owner.
+	 */
+	public function exists(): bool {
+		try {
+			$this->getNode();
+			return true;
+		} catch (NotFound) {
+			return false;
 		}
 	}
 

--- a/lib/Sabre/Album/AlbumRootBase.php
+++ b/lib/Sabre/Album/AlbumRootBase.php
@@ -26,6 +26,9 @@ use Sabre\DAV\ICopyTarget;
 use Sabre\DAV\INode;
 
 abstract class AlbumRootBase implements ICollection, ICopyTarget {
+	/** @var AlbumPhoto[]|null */
+	private ?array $children = null;
+
 	public function __construct(
 		protected AlbumMapper $albumMapper,
 		protected AlbumWithFiles $album,
@@ -86,7 +89,7 @@ abstract class AlbumRootBase implements ICollection, ICopyTarget {
 			$newName = $photosFolder->getNonExistingName($name);
 
 			$node = $photosFolder->newFile($newName, $data);
-			$this->addFile($node->getId(), $node->getOwner()->getUID());
+			$this->addFileToAlbum($node->getId(), $node->getOwner()->getUID());
 			// Cheating with header because we are using fileID-fileName
 			// https://github.com/nextcloud/server/blob/af29b978078ffd9169a9bd9146feccbb7974c900/apps/dav/lib/Connector/Sabre/FilesPlugin.php#L564-L585
 			\header('OC-FileId: ' . $node->getId());
@@ -109,7 +112,7 @@ abstract class AlbumRootBase implements ICollection, ICopyTarget {
 			throw new Forbidden("Can't add file to album, only files from $uid can be added");
 		}
 
-		return $this->addFile($sourceId, $ownerUID);
+		return $this->addFileToAlbum($sourceId, $ownerUID);
 	}
 
 	#[\Override]
@@ -120,11 +123,21 @@ abstract class AlbumRootBase implements ICollection, ICopyTarget {
 	abstract public function getAlbumPhoto(AlbumFile $file): AlbumPhoto;
 
 	/**
+	 * Entries whose file the owner can no longer reach are left out: listing
+	 * them would only produce children without properties, and a cover or a
+	 * date range taken from a file that is not there.
+	 *
+	 * Resolving costs a lookup per photo, hence the per-request cache - a
+	 * single PROPFIND otherwise walks the children several times over.
+	 *
 	 * @return AlbumPhoto[]
 	 */
 	#[\Override]
 	final public function getChildren(): array {
-		return array_map(fn (AlbumFile $file) => $this->getAlbumPhoto($file), $this->album->getFiles());
+		return $this->children ??= array_values(array_filter(
+			array_map(fn (AlbumFile $file): AlbumPhoto => $this->getAlbumPhoto($file), $this->album->getFiles()),
+			fn (AlbumPhoto $photo): bool => $photo->exists(),
+		));
 	}
 
 	#[\Override]
@@ -155,6 +168,16 @@ abstract class AlbumRootBase implements ICollection, ICopyTarget {
 
 	abstract protected function addFile(int $sourceId, string $ownerUID);
 
+	/**
+	 * Add a file and drop the resolved children, which just went stale.
+	 */
+	final protected function addFileToAlbum(int $sourceId, string $ownerUID): bool {
+		$added = $this->addFile($sourceId, $ownerUID);
+		$this->children = null;
+
+		return $added;
+	}
+
 	final public function getAlbum(): AlbumWithFiles {
 		return $this->album;
 	}
@@ -166,7 +189,11 @@ abstract class AlbumRootBase implements ICollection, ICopyTarget {
 		foreach ($this->getChildren() as $child) {
 			try {
 				$childCreationDate = $child->getFileInfo()->getMtime();
-			} catch (NotFoundException $e) {
+			} catch (NotFoundException|NotFound $e) {
+				// An album entry whose file cannot be resolved anymore must not
+				// take the whole album listing down with it.
+				// AlbumPhoto throws the Sabre exception, the other collections
+				// throw the OCP one.
 				continue;
 			}
 

--- a/lib/Sabre/PropFindPlugin.php
+++ b/lib/Sabre/PropFindPlugin.php
@@ -22,6 +22,7 @@ use OCP\FilesMetadata\IFilesMetadataManager;
 use OCP\IPreview;
 use OCP\IUserSession;
 use Sabre\DAV\Exception\Forbidden;
+use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\ICollection;
 use Sabre\DAV\INode;
 use Sabre\DAV\PropFind;
@@ -82,9 +83,10 @@ class PropFindPlugin extends ServerPlugin {
 		if ($node instanceof AlbumPhoto || $node instanceof PlacePhoto) {
 			// Checking if the node is truly available and ignoring if not
 			// Should be pre-emptively handled by the NodeDeletedEvent
+			// AlbumPhoto throws the Sabre exception, PlacePhoto the OCP one.
 			try {
 				$fileInfo = $node->getFileInfo();
-			} catch (NotFoundException) {
+			} catch (NotFoundException|NotFound) {
 				return;
 			}
 


### PR DESCRIPTION
- resolves https://github.com/nextcloud/photos/issues/3513

If a Photo is trashed or for another reason no longer available to the user (e.g. owner changed using ownership transfer) this would cause the album to be out-of-date and throw a 404.
This properly filters out those photos from the album to make it not hard-fail.


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
