### PR TITLE
feat(albums): weekly job removing orphan album entries

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -29,6 +29,7 @@
 
     <background-jobs>
         <job>OCA\Photos\Jobs\AutomaticPlaceMapperJob</job>
+        <job>OCA\Photos\Jobs\CleanupOrphanAlbumFilesJob</job>
     </background-jobs>
 
     <repair-steps>

--- a/lib/Album/AlbumMapper.php
+++ b/lib/Album/AlbumMapper.php
@@ -308,6 +308,71 @@ class AlbumMapper {
 		}
 	}
 
+	/**
+	 * Remove album entries whose file is gone from the file cache.
+	 *
+	 * @param int $limit How many orphan file ids to take on at most
+	 * @return int The number of removed entries.
+	 */
+	public function deleteOrphanFiles(int $limit): int {
+		$deleted = 0;
+		while ($limit > 0) {
+			$sqlLimit = min($limit, 1000);
+
+			$qbOuter = $this->connection->getQueryBuilder();
+			$qbInner = $this->connection->getQueryBuilder();
+			$innerQuery = $qbInner->selectDistinct('af.file_id')
+				->from('photos_albums_files', 'af')
+				->leftJoin('af', 'filecache', 'fc', $qbInner->expr()->eq('af.file_id', 'fc.fileid'))
+				->where($qbInner->expr()->isNull('fc.fileid'))
+				->setMaxResults($sqlLimit);
+
+			// fix for MySQL which needs a nested table, as directly selecting from a table that is being deleted is not possible.
+			$orphans = $qbOuter->createFunction('SELECT file_id FROM (' . $innerQuery->getSQL() . ') orphans');
+
+			$removed = $qbOuter->delete('photos_albums_files')
+				->where($qbOuter->expr()->in('file_id', $orphans))
+				->executeStatement();
+
+			// Nothing left to collect, no point running the remaining passes.
+			if ($removed === 0) {
+				break;
+			}
+
+			$deleted += $removed;
+			$limit -= $sqlLimit;
+		}
+
+		$this->repairOrphanCovers();
+
+		return $deleted;
+	}
+
+	/**
+	 * Give a new cover to albums whose cover is a file the cache no longer knows.
+	 *
+	 * Derived from the albums themselves rather than from what was just deleted,
+	 * so it also repairs covers left dangling by an earlier run or an older bug.
+	 */
+	private function repairOrphanCovers(): void {
+		$query = $this->connection->getQueryBuilder();
+		$albumIds = $query->select('a.album_id')
+			->from('photos_albums', 'a')
+			->leftJoin('a', 'filecache', 'fc', $query->expr()->eq('a.last_added_photo', 'fc.fileid'))
+			->where($query->expr()->neq('a.last_added_photo', $query->createNamedParameter(-1, IQueryBuilder::PARAM_INT)))
+			->andWhere($query->expr()->isNull('fc.fileid'))
+			->executeQuery()
+			->fetchFirstColumn();
+
+		foreach ($albumIds as $albumId) {
+			$query = $this->connection->getQueryBuilder();
+			$query->update('photos_albums')
+				->set('last_added_photo', $query->createNamedParameter($this->getLastAdded((int)$albumId), IQueryBuilder::PARAM_INT))
+				->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
+				->executeStatement();
+		}
+	}
+
 	private function getLastAdded(int $albumId): int {
 		$query = $this->connection->getQueryBuilder();
 		$query->select('file_id')

--- a/lib/Jobs/CleanupOrphanAlbumFilesJob.php
+++ b/lib/Jobs/CleanupOrphanAlbumFilesJob.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Photos\Jobs;
+
+use OCA\Photos\Album\AlbumMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
+use OCP\BackgroundJob\TimedJob;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Drop album entries that point at files which no longer exist.
+ *
+ * AlbumsManagementEventListener already removes them when it sees the deletion,
+ * but it cannot see every way a file can go away - changes made outside of
+ * Nextcloud and only picked up by a scan, for instance. What is left behind is
+ * an entry that resolves to no node, which every listing of that album then has
+ * to work around. This job collects them once a week instead.
+ */
+class CleanupOrphanAlbumFilesJob extends TimedJob {
+	private const int BATCH_SIZE = 1000;
+	private const int INTERVAL = 7 * 24 * 3600;
+
+	public function __construct(
+		ITimeFactory $time,
+		private readonly AlbumMapper $albumMapper,
+		private readonly LoggerInterface $logger,
+	) {
+		parent::__construct($time);
+
+		$this->setInterval(self::INTERVAL);
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+	}
+
+	#[\Override]
+	protected function run($argument): void {
+		$deleted = $this->albumMapper->deleteOrphanFiles(self::BATCH_SIZE);
+
+		if ($deleted > 0) {
+			$this->logger->info('Removed ' . $deleted . ' orphan album entries', ['app' => 'photos']);
+		}
+	}
+}

--- a/tests/Album/AlbumMapperTest.php
+++ b/tests/Album/AlbumMapperTest.php
@@ -114,6 +114,166 @@ class AlbumMapperTest extends TestCase {
 		return $id;
 	}
 
+	/**
+	 * Take a file out of the cache without telling anyone, the way a file can
+	 * go missing when the deletion never reaches AlbumsManagementEventListener.
+	 */
+	private function removeFromCache(int $fileId): void {
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('filecache')
+			->where($query->expr()->eq('fileid', $query->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)))
+			->executeStatement();
+	}
+
+	/**
+	 * Read the album entries straight from the table: the regular queries join
+	 * the file cache and would hide exactly the rows these tests are about.
+	 *
+	 * @return int[]
+	 */
+	private function getAlbumFileIds(int $albumId): array {
+		$query = $this->connection->getQueryBuilder();
+		$fileIds = $query->select('file_id')
+			->from('photos_albums_files')
+			->where($query->expr()->eq('album_id', $query->createNamedParameter($albumId, IQueryBuilder::PARAM_INT)))
+			->orderBy('file_id', 'ASC')
+			->executeQuery()
+			->fetchFirstColumn();
+
+		return array_map(intval(...), $fileIds);
+	}
+
+	public function testDeleteOrphanFilesRemovesOnlyEntriesWithoutAFile() {
+		$album = $this->mapper->create('user1', 'album1');
+		$keptFile = $this->createFile('kept', 'image/png');
+		$goneFile = $this->createFile('gone', 'image/png');
+
+		$this->time = 110;
+		$this->mapper->addFile($album->getId(), $keptFile, 'user1');
+		$this->time = 120;
+		$this->mapper->addFile($album->getId(), $goneFile, 'user1');
+
+		$this->removeFromCache($goneFile);
+
+		$this->assertEquals(1, $this->mapper->deleteOrphanFiles(1000));
+		$this->assertEquals([$keptFile], $this->getAlbumFileIds($album->getId()));
+	}
+
+	public function testDeleteOrphanFilesLeavesAHealthyAlbumAlone() {
+		$album = $this->mapper->create('user1', 'album1');
+		$file1 = $this->createFile('file1', 'image/png');
+		$file2 = $this->createFile('file2', 'image/png');
+
+		$this->time = 110;
+		$this->mapper->addFile($album->getId(), $file1, 'user1');
+		$this->time = 120;
+		$this->mapper->addFile($album->getId(), $file2, 'user1');
+
+		$this->assertEquals(0, $this->mapper->deleteOrphanFiles(1000));
+		$this->assertEquals([$file1, $file2], $this->getAlbumFileIds($album->getId()));
+		$this->assertEquals($file2, $this->mapper->get($album->getId())->getLastAddedPhoto());
+	}
+
+	/**
+	 * A file id is either cached or it is not, so it is stale in every album at
+	 * once - and the return value counts entries, not files.
+	 */
+	public function testDeleteOrphanFilesRemovesTheFileFromEveryAlbum() {
+		$album1 = $this->mapper->create('user1', 'album1');
+		$album2 = $this->mapper->create('user1', 'album2');
+		$goneFile = $this->createFile('gone', 'image/png');
+
+		$this->time = 110;
+		$this->mapper->addFile($album1->getId(), $goneFile, 'user1');
+		$this->mapper->addFile($album2->getId(), $goneFile, 'user1');
+
+		$this->removeFromCache($goneFile);
+
+		$this->assertEquals(2, $this->mapper->deleteOrphanFiles(1000));
+		$this->assertEquals([], $this->getAlbumFileIds($album1->getId()));
+		$this->assertEquals([], $this->getAlbumFileIds($album2->getId()));
+	}
+
+	public function testDeleteOrphanFilesGivesTheAlbumANewCover() {
+		$album = $this->mapper->create('user1', 'album1');
+		$keptFile = $this->createFile('kept', 'image/png');
+		$coverFile = $this->createFile('cover', 'image/png');
+
+		$this->time = 110;
+		$this->mapper->addFile($album->getId(), $keptFile, 'user1');
+		$this->time = 120;
+		$this->mapper->addFile($album->getId(), $coverFile, 'user1');
+		$this->assertEquals($coverFile, $this->mapper->get($album->getId())->getLastAddedPhoto());
+
+		$this->removeFromCache($coverFile);
+		$this->mapper->deleteOrphanFiles(1000);
+
+		$this->assertEquals($keptFile, $this->mapper->get($album->getId())->getLastAddedPhoto());
+	}
+
+	/**
+	 * The cover is repaired from the albums themselves, not from what was just
+	 * deleted, so a cover left dangling by an earlier run gets picked up on the
+	 * next one even though there is nothing left to delete.
+	 */
+	public function testDeleteOrphanFilesRepairsADanglingCoverOnItsOwn() {
+		$album = $this->mapper->create('user1', 'album1');
+		$keptFile = $this->createFile('kept', 'image/png');
+		$coverFile = $this->createFile('cover', 'image/png');
+
+		$this->time = 110;
+		$this->mapper->addFile($album->getId(), $keptFile, 'user1');
+		$this->time = 120;
+		$this->mapper->addFile($album->getId(), $coverFile, 'user1');
+
+		// Drop the entry without going through removeFile(), which would
+		// refresh the cover: only the stale cover is left behind.
+		$query = $this->connection->getQueryBuilder();
+		$query->delete('photos_albums_files')
+			->where($query->expr()->eq('file_id', $query->createNamedParameter($coverFile, IQueryBuilder::PARAM_INT)))
+			->executeStatement();
+		$this->removeFromCache($coverFile);
+
+		$this->assertEquals(0, $this->mapper->deleteOrphanFiles(1000));
+		$this->assertEquals($keptFile, $this->mapper->get($album->getId())->getLastAddedPhoto());
+	}
+
+	public function testDeleteOrphanFilesClearsTheCoverOfAnEmptiedAlbum() {
+		$album = $this->mapper->create('user1', 'album1');
+		$goneFile = $this->createFile('gone', 'image/png');
+
+		$this->time = 110;
+		$this->mapper->addFile($album->getId(), $goneFile, 'user1');
+
+		$this->removeFromCache($goneFile);
+		$this->mapper->deleteOrphanFiles(1000);
+
+		$this->assertEquals([], $this->getAlbumFileIds($album->getId()));
+		$this->assertEquals(-1, $this->mapper->get($album->getId())->getLastAddedPhoto());
+	}
+
+	/**
+	 * The limit counts orphan files, so that a large backlog is worked off over
+	 * several runs rather than in one long statement.
+	 */
+	public function testDeleteOrphanFilesStopsAtTheLimit() {
+		$album = $this->mapper->create('user1', 'album1');
+
+		$this->time = 110;
+		foreach (['gone1', 'gone2', 'gone3'] as $name) {
+			$fileId = $this->createFile($name, 'image/png');
+			$this->mapper->addFile($album->getId(), $fileId, 'user1');
+			$this->removeFromCache($fileId);
+			$this->time += 10;
+		}
+
+		$this->assertEquals(2, $this->mapper->deleteOrphanFiles(2));
+		$this->assertCount(1, $this->getAlbumFileIds($album->getId()));
+
+		$this->assertEquals(1, $this->mapper->deleteOrphanFiles(2));
+		$this->assertEquals([], $this->getAlbumFileIds($album->getId()));
+	}
+
 	public function testCreateGet() {
 		$album = $this->mapper->create('user1', 'album1');
 


### PR DESCRIPTION
- follow up on #3765 

Album membership lives in its own table, keyed by file id.
There are some reasons (trashbin, ownership transfer) that can cause this getting out of sync with the files cache and not everything can be handled by `AlbumsManagementEventListener` to prunes it.

This adds a background job to remove those cases from the album.

**DISCUSSION**: Should we exclude trashbin files?

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
