### PR TITLE
feat: zoom and pan photos in the slideshow

### DIFF
--- a/src/components/PhotoSlideshow.vue
+++ b/src/components/PhotoSlideshow.vue
@@ -16,11 +16,28 @@
 		@previous="showPrevious"
 		@next="showNext"
 		@close="emit('close')">
-		<img
+		<!-- Zoom/pan surface: pinch or wheel to zoom, drag to pan, double-tap to toggle. -->
+		<div
 			v-if="currentPhoto !== undefined"
-			class="slideshow__photo"
-			:src="getPreviewUrl(currentPhoto, PREVIEW_SIZE)"
-			:alt="currentPhoto.basename">
+			ref="viewport"
+			class="slideshow__viewport"
+			:class="{
+				'slideshow__viewport--zoomed': scale > MIN_SCALE,
+				'slideshow__viewport--interacting': interacting,
+			}"
+			@pointerdown="onPointerDown"
+			@pointermove="onPointerMove"
+			@pointerup="onPointerUp"
+			@pointercancel="onPointerUp"
+			@wheel.prevent="onWheel"
+			@dblclick="onDoubleClick">
+			<img
+				class="slideshow__photo"
+				:style="imageStyle"
+				:src="getPreviewUrl(currentPhoto, PREVIEW_SIZE)"
+				:alt="currentPhoto.basename"
+				draggable="false">
+		</div>
 
 		<!-- How far into the set the slideshow is, as the header only names the photo. -->
 		<p class="slideshow__position">
@@ -56,6 +73,7 @@ import NcModal from '@nextcloud/vue/components/NcModal'
 import { fetchPhotoExif } from '../services/exifFetcher.ts'
 import { getExifSummary } from '../utils/exif.ts'
 import { getPreviewUrl, toPhotoTarget } from '../utils/fileUtils.ts'
+import { clampOffset, clampScale, distance, MIN_SCALE, toggledScale } from '../utils/panZoom.ts'
 
 const props = withDefaults(defineProps<{
 	/** Photos to play through, in the order they are shown. */
@@ -81,6 +99,130 @@ const index = ref(props.startIndex)
 
 const currentPhoto = computed<PhotoFile | undefined>(() => props.photos[index.value])
 
+// --- Zoom & pan state ---------------------------------------------------------
+const viewport = ref<HTMLElement | null>(null)
+const scale = ref(MIN_SCALE)
+const offsetX = ref(0)
+const offsetY = ref(0)
+/** True while a pointer gesture is in progress, to drop the zoom transition. */
+const interacting = ref(false)
+
+/** Live pointers by id, so one is a pan and two are a pinch. */
+const pointers = new Map<number, { x: number, y: number }>()
+let pinchStartDistance = 0
+let pinchStartScale = MIN_SCALE
+let lastPanX = 0
+let lastPanY = 0
+
+const imageStyle = computed(() => ({
+	transform: `translate(${offsetX.value}px, ${offsetY.value}px) scale(${scale.value})`,
+}))
+
+/** Reset to the fitted, centred photo — on open, on zoom-out and on photo change. */
+function resetZoom(): void {
+	scale.value = MIN_SCALE
+	offsetX.value = 0
+	offsetY.value = 0
+}
+
+function clampPan(x: number, y: number): void {
+	const width = viewport.value?.clientWidth ?? 0
+	const height = viewport.value?.clientHeight ?? 0
+	offsetX.value = clampOffset(x, scale.value, width)
+	offsetY.value = clampOffset(y, scale.value, height)
+}
+
+/**
+ * Apply a new zoom (clamped), pausing the slideshow so it does not advance past it.
+ *
+ * @param next - Desired zoom before clamping
+ */
+function setScale(next: number): void {
+	const clamped = clampScale(next)
+	if (clamped > MIN_SCALE) {
+		pauseAutoplay()
+		scale.value = clamped
+		clampPan(offsetX.value, offsetY.value)
+	} else {
+		resetZoom()
+	}
+}
+
+function onPointerDown(event: PointerEvent): void {
+	pointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
+	interacting.value = true
+
+	if (pointers.size === 2) {
+		const [a, b] = [...pointers.values()]
+		pinchStartDistance = distance(a, b)
+		pinchStartScale = scale.value
+		pointers.forEach((_, id) => (event.target as Element).setPointerCapture?.(id))
+		// Don't let the pinch reach the modal's swipe navigation.
+		event.stopPropagation()
+	} else if (scale.value > MIN_SCALE) {
+		// A single drag pans only once zoomed; otherwise it stays a modal swipe.
+		lastPanX = event.clientX
+		lastPanY = event.clientY;
+		(event.target as Element).setPointerCapture?.(event.pointerId)
+		event.stopPropagation()
+	}
+}
+
+function onPointerMove(event: PointerEvent): void {
+	if (!pointers.has(event.pointerId)) {
+		return
+	}
+	pointers.set(event.pointerId, { x: event.clientX, y: event.clientY })
+
+	if (pointers.size >= 2) {
+		const [a, b] = [...pointers.values()]
+		if (pinchStartDistance > 0) {
+			setScale(pinchStartScale * (distance(a, b) / pinchStartDistance))
+		}
+		event.stopPropagation()
+	} else if (scale.value > MIN_SCALE) {
+		clampPan(offsetX.value + event.clientX - lastPanX, offsetY.value + event.clientY - lastPanY)
+		lastPanX = event.clientX
+		lastPanY = event.clientY
+		event.stopPropagation()
+	}
+}
+
+function onPointerUp(event: PointerEvent): void {
+	pointers.delete(event.pointerId)
+	if (pointers.size < 2) {
+		pinchStartDistance = 0
+	}
+	// If one finger is left after a pinch, keep panning from where it is.
+	if (pointers.size === 1) {
+		const [remaining] = [...pointers.values()]
+		lastPanX = remaining.x
+		lastPanY = remaining.y
+	}
+	if (pointers.size === 0) {
+		interacting.value = false
+	}
+}
+
+/**
+ * Zoom with the mouse wheel. Typed structurally rather than as `WheelEvent`,
+ * which collides with the React JSX event types in the type environment and
+ * vue-tsc then rejects on a native element.
+ *
+ * @param event - The wheel event, of which only the scroll amount is used
+ * @param event.deltaY - Vertical scroll amount; its sign gives the zoom direction
+ */
+function onWheel(event: { deltaY: number }): void {
+	setScale(scale.value - Math.sign(event.deltaY) * 0.3)
+}
+
+function onDoubleClick(): void {
+	setScale(toggledScale(scale.value))
+}
+
+// A photo change (manual, or the slideshow advancing) starts fresh at fit.
+watch(index, resetZoom)
+
 const positionLabel = computed<string>(() => t('photos', '{position} of {count}', {
 	position: index.value + 1,
 	count: props.photos.length,
@@ -96,9 +238,28 @@ const exifEntries = ref<ExifEntry[]>([])
 /** Discards the metadata of a photo which is not on screen anymore. */
 let pendingRequest = 0
 
+/** Best-effort mirror of the modal's slideshow play state (see pauseAutoplay). */
+const isPlaying = ref(false)
+
 // The slideshow is only mounted when the user asked for it, so it plays right
 // away instead of waiting for the play button of the modal to be pressed.
-onMounted(() => modal.value?.togglePlayPause())
+onMounted(() => {
+	modal.value?.togglePlayPause()
+	isPlaying.value = true
+})
+
+/**
+ * Pause the slideshow so it stops advancing while the user inspects a zoomed
+ * photo. The modal only exposes a toggle, so we track our own play flag; if the
+ * user also uses the modal's own play button the two can desync, which at worst
+ * costs one extra tap to resume — never a broken state.
+ */
+function pauseAutoplay(): void {
+	if (isPlaying.value) {
+		modal.value?.togglePlayPause()
+		isPlaying.value = false
+	}
+}
 
 // The modal takes the focus, so the shortcut is bound to the document rather
 // than to an element of the slideshow.
@@ -143,12 +304,30 @@ function onKeyDown(event: KeyboardEvent): void {
 		return
 	}
 
+	// Zoom from the keyboard, so pointer gestures are not the only way in.
+	if (event.key === '+' || event.key === '=') {
+		event.preventDefault()
+		setScale(scale.value + 0.5)
+		return
+	}
+	if (event.key === '-') {
+		event.preventDefault()
+		setScale(scale.value - 0.5)
+		return
+	}
+	if (event.key === '0') {
+		event.preventDefault()
+		resetZoom()
+		return
+	}
+
 	// Space plays and pauses, unless a control has the focus: the press activates
 	// that control on its own, and toggling on top of it would take it back.
 	if (event.key === ' ' && !isControl(event.target)) {
 		// Without this the page behind the slideshow scrolls as well.
 		event.preventDefault()
 		modal.value?.togglePlayPause()
+		isPlaying.value = !isPlaying.value
 	}
 }
 
@@ -162,10 +341,43 @@ function isControl(target: EventTarget | null): boolean {
 </script>
 
 <style lang="scss" scoped>
+.slideshow__viewport {
+	display: flex;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	// We drive zoom and pan ourselves, so suppress the browser's own touch gestures.
+	touch-action: none;
+
+	&--zoomed {
+		cursor: grab;
+	}
+
+	&--zoomed.slideshow__viewport--interacting {
+		cursor: grabbing;
+	}
+}
+
 .slideshow__photo {
 	width: 100%;
 	height: 100%;
 	object-fit: contain;
+	transform-origin: center center;
+	transition: transform var(--animation-quick) ease-out;
+	// Drag pans the photo; it should never start a native image drag or selection.
+	user-select: none;
+	-webkit-user-drag: none;
+}
+
+// No transition mid-gesture, so a pinch or drag tracks the fingers exactly.
+.slideshow__viewport--interacting .slideshow__photo {
+	transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.slideshow__photo {
+		transition: none;
+	}
 }
 
 .slideshow__position {

--- a/src/utils/panZoom.spec.ts
+++ b/src/utils/panZoom.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+	clampOffset,
+	clampScale,
+	distance,
+	DOUBLE_TAP_SCALE,
+	MAX_SCALE,
+	maxOffset,
+	MIN_SCALE,
+	toggledScale,
+} from './panZoom.ts'
+
+describe('clampScale', () => {
+	it('keeps a scale that is already in range', () => {
+		expect(clampScale(2)).toBe(2)
+	})
+
+	it('clamps below the minimum up to MIN_SCALE', () => {
+		expect(clampScale(0.2)).toBe(MIN_SCALE)
+	})
+
+	it('clamps above the maximum down to MAX_SCALE', () => {
+		expect(clampScale(99)).toBe(MAX_SCALE)
+	})
+})
+
+describe('maxOffset', () => {
+	it('is zero at the fitted size, so a non-zoomed photo cannot pan', () => {
+		expect(maxOffset(1, 1000)).toBe(0)
+	})
+
+	it('grows with the zoom: half the extra width at 2x', () => {
+		expect(maxOffset(2, 1000)).toBe(500)
+	})
+
+	it('never returns a negative limit', () => {
+		expect(maxOffset(0.5, 1000)).toBe(0)
+	})
+})
+
+describe('clampOffset', () => {
+	it('leaves an offset within the limit untouched', () => {
+		expect(clampOffset(100, 2, 1000)).toBe(100)
+	})
+
+	it('clamps a positive offset to the limit', () => {
+		expect(clampOffset(9999, 2, 1000)).toBe(500)
+	})
+
+	it('clamps a negative offset to the negative limit', () => {
+		expect(clampOffset(-9999, 2, 1000)).toBe(-500)
+	})
+
+	it('pins the offset to zero when not zoomed', () => {
+		expect(clampOffset(200, 1, 1000)).toBe(0)
+	})
+})
+
+describe('distance', () => {
+	it('measures the euclidean distance between two points', () => {
+		expect(distance({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5)
+	})
+})
+
+describe('toggledScale', () => {
+	it('zooms in from the fitted size', () => {
+		expect(toggledScale(MIN_SCALE)).toBe(DOUBLE_TAP_SCALE)
+	})
+
+	it('zooms back out when already zoomed in', () => {
+		expect(toggledScale(3)).toBe(MIN_SCALE)
+	})
+})

--- a/src/utils/panZoom.ts
+++ b/src/utils/panZoom.ts
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/** Smallest zoom: the photo fitted to the viewport. */
+export const MIN_SCALE = 1
+
+/** Largest zoom, to keep a photo from turning into a wall of pixels. */
+export const MAX_SCALE = 5
+
+/** Zoom a double-click / double-tap jumps to from the fitted size. */
+export const DOUBLE_TAP_SCALE = 2.5
+
+/**
+ * Clamp a zoom factor to the allowed range.
+ *
+ * @param scale - Desired zoom
+ */
+export function clampScale(scale: number): number {
+	return Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale))
+}
+
+/**
+ * How far, in pixels, the scaled content may be panned along one axis before its
+ * edge would cross the centre of the viewport. Zero at the fitted size, so a
+ * non-zoomed photo cannot be dragged around at all.
+ *
+ * @param scale - Current zoom
+ * @param viewportSize - Viewport length on this axis, in pixels
+ */
+export function maxOffset(scale: number, viewportSize: number): number {
+	return Math.max(0, (scale - 1) * viewportSize / 2)
+}
+
+/**
+ * Clamp a pan offset so the scaled content cannot be dragged off the viewport.
+ *
+ * @param offset - Desired offset in pixels
+ * @param scale - Current zoom
+ * @param viewportSize - Viewport length on this axis, in pixels
+ */
+export function clampOffset(offset: number, scale: number, viewportSize: number): number {
+	const limit = maxOffset(scale, viewportSize)
+	return Math.min(limit, Math.max(-limit, offset))
+}
+
+export type Point = { x: number, y: number }
+
+/**
+ * Distance between two points, e.g. the two pointers of a pinch.
+ *
+ * @param a - First point
+ * @param a.x - First point, x coordinate
+ * @param a.y - First point, y coordinate
+ * @param b - Second point
+ * @param b.x - Second point, x coordinate
+ * @param b.y - Second point, y coordinate
+ */
+export function distance(a: Point, b: Point): number {
+	return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+/**
+ * The zoom a double-tap toggles to: back to the fitted size when already zoomed
+ * in, otherwise in to the default zoom.
+ *
+ * @param scale - Current zoom
+ */
+export function toggledScale(scale: number): number {
+	return scale > MIN_SCALE ? MIN_SCALE : DOUBLE_TAP_SCALE
+}


### PR DESCRIPTION
## What

The Photos **slideshow** (`PhotoSlideshow.vue`) could only show each photo fitted to the screen — no way to look closer. This adds zoom and pan:

- **Pinch** to zoom + **drag** to pan on touch
- **Mouse wheel** to zoom + **drag** to pan with a pointer
- **Double-click / double-tap** to toggle between fit and zoom
- **`+` / `-` / `0`** to zoom in / out / reset from the keyboard, so pointer gestures aren't the only way in (accessibility)

## Behaviour details

- **Pan is clamped** so a photo can never be dragged off screen, and **zoom resets when the shown photo changes** (manual navigation or the slideshow advancing).
- **Zooming pauses the slideshow** so it doesn't advance past the photo you're inspecting.
- **Swipe still works:** while a photo is at fit (1×), a horizontal drag reaches the modal as a swipe to the next photo; once zoomed, drags pan instead and are kept from the modal's swipe navigation.
- Motion honours **`prefers-reduced-motion`**, and the zoom transition is dropped mid-gesture so a pinch/drag tracks the fingers exactly.

## Structure & tests

- The pan/zoom maths (scale clamping, pan-offset clamping, pinch distance, double-tap toggle) lives in a small pure `src/utils/panZoom.ts` with a full `panZoom.spec.ts` (13 cases). The component just wires pointer/wheel/keyboard events to it.
- Full `npm test` green (78 tests). `npm run lint` clean for the changed files; the pre-existing repo-wide `ts:check` errors are in unrelated files (this change adds none).

## Verification

Verified on a dev instance: keyboard `+`/`-` zoom (transform goes 1× → 2×), double-click toggles back to fit, and the zoom persists rather than being reset by auto-advance (confirming the autoplay pause). Screenshot of a photo zoomed inside the slideshow attached in review.

Source only; `js/`/`css/` will need the usual asset compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)