### PR TITLE
feat: add a duplicate finder

### DIFF
--- a/src/components/Settings/SettingsDialog.vue
+++ b/src/components/Settings/SettingsDialog.vue
@@ -14,6 +14,14 @@
 			<PhotosUploadLocationSettings />
 			<CroppedLayoutSettings />
 		</NcAppSettingsSection>
+		<NcAppSettingsSection id="tools-settings" :name="t('photos', 'Tools')">
+			<NcButton @click="openDuplicates">
+				<template #icon>
+					<ContentDuplicate :size="20" />
+				</template>
+				{{ t('photos', 'Find duplicate photos') }}
+			</NcButton>
+		</NcAppSettingsSection>
 	</NcAppSettingsDialog>
 </template>
 
@@ -21,6 +29,8 @@
 import { t } from '@nextcloud/l10n'
 import NcAppSettingsDialog from '@nextcloud/vue/components/NcAppSettingsDialog'
 import NcAppSettingsSection from '@nextcloud/vue/components/NcAppSettingsSection'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import ContentDuplicate from 'vue-material-design-icons/ContentDuplicate.vue'
 import CroppedLayoutSettings from './CroppedLayoutSettings.vue'
 import PhotosSourceLocationsSettings from './PhotosSourceLocationsSettings.vue'
 import PhotosUploadLocationSettings from './PhotosUploadLocationSettings.vue'
@@ -31,6 +41,8 @@ export default {
 	components: {
 		NcAppSettingsDialog,
 		NcAppSettingsSection,
+		NcButton,
+		ContentDuplicate,
 		CroppedLayoutSettings,
 		PhotosSourceLocationsSettings,
 		PhotosUploadLocationSettings,
@@ -48,6 +60,12 @@ export default {
 		// is shown. So closing only
 		onClose() {
 			this.$emit('update:open', false)
+		},
+
+		// Close the settings and open the (full-page) duplicate finder.
+		openDuplicates() {
+			this.$emit('update:open', false)
+			this.$router.push({ name: 'duplicates' }).catch(() => {})
 		},
 
 		t,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -11,6 +11,7 @@ import { imageMimes, videoMimes } from '../services/AllowedMimes.js'
 import areTagsInstalled from '../services/AreTagsInstalled.js'
 import isRecognizeInstalled from '../services/IsRecognizeInstalled.js'
 
+const DuplicatesView = () => import('../views/DuplicatesView.vue')
 const FoldersView = () => import('../views/FoldersView.vue')
 const MapView = () => import('../views/MapView.vue')
 const MemoriesView = () => import('../views/MemoriesView.vue')
@@ -268,6 +269,19 @@ const router = new Router({
 			meta: {
 				rootTitle: () => {
 					return t('photos', 'Memories')
+				},
+			},
+		},
+		{
+			path: '/duplicates',
+			name: 'duplicates',
+			component: DuplicatesView,
+			props: () => ({
+				rootTitle: t('photos', 'Duplicates'),
+			}),
+			meta: {
+				rootTitle: () => {
+					return t('photos', 'Duplicates')
 				},
 			},
 		},

--- a/src/utils/duplicates.spec.ts
+++ b/src/utils/duplicates.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { PhotoFile } from '../store/files.ts'
+
+import { describe, expect, it } from 'vitest'
+import { findDuplicateGroups } from './duplicates.ts'
+
+/**
+ * Build a minimal photo with a byte size and optional pixel dimensions.
+ *
+ * @param fileid - File id of the photo
+ * @param size - Byte size
+ * @param width - Pixel width
+ * @param height - Pixel height
+ */
+function photo(fileid: number, size: number, width = 100, height = 100): PhotoFile {
+	return {
+		fileid,
+		size,
+		attributes: { 'metadata-photos-size': { width, height } },
+	} as unknown as PhotoFile
+}
+
+describe('findDuplicateGroups', () => {
+	it('returns nothing when every photo is a different size', () => {
+		expect(findDuplicateGroups([photo(1, 100), photo(2, 200), photo(3, 300)])).toEqual([])
+	})
+
+	it('groups photos that share a byte size', () => {
+		const groups = findDuplicateGroups([photo(1, 500), photo(2, 500), photo(3, 999)])
+
+		expect(groups).toHaveLength(1)
+		expect(groups[0].photos.map((p) => p.fileid)).toEqual([1, 2])
+		expect(groups[0].size).toBe(500)
+	})
+
+	it('groups photos of equal size even when their dimensions differ', () => {
+		// Dimensions are only filled in by a background job, so they must not gate
+		// the match — a freshly added copy would otherwise be missed.
+		const groups = findDuplicateGroups([photo(1, 500, 100, 100), photo(2, 500, 4000, 3000)])
+
+		expect(groups).toHaveLength(1)
+		expect(groups[0].photos.map((p) => p.fileid)).toEqual([1, 2])
+	})
+
+	it('skips photos without a real byte size', () => {
+		const noSize = { fileid: 1, size: 0, attributes: {} } as unknown as PhotoFile
+
+		expect(findDuplicateGroups([noSize, photo(2, 500)])).toEqual([])
+	})
+
+	it('orders groups by copy count first, then by size', () => {
+		const groups = findDuplicateGroups([
+			// Two copies of a large file.
+			photo(1, 9000),
+			photo(2, 9000),
+			// Three copies of a small file.
+			photo(3, 100),
+			photo(4, 100),
+			photo(5, 100),
+		])
+
+		expect(groups.map((group) => group.photos.length)).toEqual([3, 2])
+	})
+})

--- a/src/utils/duplicates.ts
+++ b/src/utils/duplicates.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { PhotoFile } from '../store/files.ts'
+
+export type DuplicateGroup = {
+	/** Stable key and identity — the byte size shared by the group. */
+	id: string
+	/** Byte size shared by every photo in the group. */
+	size: number
+	photos: PhotoFile[]
+}
+
+/**
+ * Group photos that look like duplicates of one another.
+ *
+ * Two photos are treated as duplicates when they share an exact byte size. Two
+ * different images compressing to the very same byte count is astronomically
+ * unlikely, so this reliably catches re-uploaded copies without hashing the file
+ * contents — and the user still reviews each group before deleting anything.
+ * Size is used on its own rather than combined with pixel dimensions, which are
+ * only filled in by a background job and so are absent for freshly added files.
+ * Only groups of two or more are returned, most copies first (then largest
+ * files), so the biggest space savings surface at the top.
+ *
+ * @param photos - The photos to scan
+ */
+export function findDuplicateGroups(photos: PhotoFile[]): DuplicateGroup[] {
+	const bySize = new Map<number, PhotoFile[]>()
+
+	for (const photo of photos) {
+		const size = photo.size ?? 0
+		// A photo with no real byte size cannot be fingerprinted.
+		if (size <= 0) {
+			continue
+		}
+
+		const existing = bySize.get(size)
+		if (existing) {
+			existing.push(photo)
+		} else {
+			bySize.set(size, [photo])
+		}
+	}
+
+	return [...bySize.entries()]
+		.filter(([, group]) => group.length > 1)
+		.map(([size, group]) => ({
+			id: String(size),
+			size,
+			photos: group,
+		}))
+		.sort((a, b) => b.photos.length - a.photos.length || b.size - a.size)
+}

--- a/src/views/DuplicatesView.vue
+++ b/src/views/DuplicatesView.vue
@@ -1,0 +1,220 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="duplicates">
+		<HeaderNavigation
+			key="navigation"
+			:loading="loading"
+			path="/"
+			:title="rootTitle"
+			:root-title="rootTitle"
+			@refresh="loadPhotos" />
+
+		<NcEmptyContent
+			v-if="groups.length === 0"
+			class="duplicates__empty-content"
+			:name="loading ? t('photos', 'Looking for duplicates…') : t('photos', 'No duplicates found')"
+			:description="t('photos', 'Photos with the same size and dimensions are grouped here so you can remove the extra copies.')">
+			<template #icon>
+				<ContentDuplicate :size="64" />
+			</template>
+		</NcEmptyContent>
+
+		<ul v-else class="duplicates__list">
+			<li v-for="group in groups" :key="group.id" class="duplicates__group">
+				<h3 class="duplicates__group__title">
+					{{ n('photos', '%n copy', '%n copies', group.photos.length) }}
+					<span class="duplicates__group__meta">{{ formatFileSize(group.size) }}</span>
+				</h3>
+				<ul class="duplicates__group__grid">
+					<li v-for="photo in group.photos" :key="photo.fileid" class="duplicates__photo">
+						<button
+							type="button"
+							class="duplicates__photo__open"
+							:aria-label="t('photos', 'Open {name}', { name: photo.basename })"
+							@click="openViewer(group, photo)">
+							<img
+								class="duplicates__photo__image"
+								:src="getPreviewUrl(photo, 256)"
+								:alt="photo.basename"
+								loading="lazy"
+								decoding="async">
+						</button>
+						<NcButton
+							class="duplicates__photo__delete"
+							variant="error"
+							:aria-label="t('photos', 'Move {name} to the trash', { name: photo.basename })"
+							@click="photoToDelete = photo">
+							<template #icon>
+								<Delete :size="20" />
+							</template>
+						</NcButton>
+					</li>
+				</ul>
+			</li>
+		</ul>
+
+		<NcDialog
+			v-if="photoToDelete !== null"
+			:name="t('photos', 'Move to trash')"
+			@update:open="photoToDelete = null">
+			<p>{{ t('photos', 'Are you sure you want to move "{name}" to the trash?', { name: photoToDelete.basename }) }}</p>
+			<template #actions>
+				<NcButton variant="tertiary" @click="photoToDelete = null">
+					{{ t('photos', 'Cancel') }}
+				</NcButton>
+				<NcButton variant="error" @click="confirmDelete">
+					{{ t('photos', 'Move to trash') }}
+				</NcButton>
+			</template>
+		</NcDialog>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import type { PhotoFile } from '../store/files.ts'
+import type { DuplicateGroup } from '../utils/duplicates.ts'
+
+import { formatFileSize } from '@nextcloud/files'
+import { translatePlural as n, translate as t } from '@nextcloud/l10n'
+import { computed, onMounted, ref } from 'vue'
+import NcButton from '@nextcloud/vue/components/NcButton'
+import NcDialog from '@nextcloud/vue/components/NcDialog'
+import NcEmptyContent from '@nextcloud/vue/components/NcEmptyContent'
+import ContentDuplicate from 'vue-material-design-icons/ContentDuplicate.vue'
+import Delete from 'vue-material-design-icons/Delete.vue'
+import HeaderNavigation from '../components/HeaderNavigation.vue'
+import { useLoadedPhotos } from '../composables/useLoadedPhotos.ts'
+import store from '../store/index.ts'
+import { findDuplicateGroups } from '../utils/duplicates.ts'
+import { getPreviewUrl, toViewerFileInfo } from '../utils/fileUtils.ts'
+
+defineProps<{
+	rootTitle: string
+}>()
+
+const { photos, loading, loadPhotos } = useLoadedPhotos()
+
+const groups = computed<DuplicateGroup[]>(() => findDuplicateGroups(photos.value))
+
+// The photo pending a delete confirmation, or null when the dialog is closed.
+const photoToDelete = ref<PhotoFile | null>(null)
+
+onMounted(() => {
+	// Reuse whatever the other views already loaded; only fetch on a cold start.
+	if (photos.value.length === 0) {
+		loadPhotos()
+	}
+})
+
+/**
+ * Open a duplicate in the viewer, with the rest of its group as the viewer's
+ * list, so the copies can be compared side by side before deleting one.
+ *
+ * @param group - The duplicate group the photo belongs to
+ * @param photo - The photo to open
+ */
+function openViewer(group: DuplicateGroup, photo: PhotoFile): void {
+	window.OCA.Viewer.open({
+		fileInfo: toViewerFileInfo(photo),
+		list: group.photos.map((duplicate) => toViewerFileInfo(duplicate)),
+	})
+}
+
+/** Move the pending photo to the trash (recoverable). The group shrinks live. */
+async function confirmDelete(): Promise<void> {
+	const photo = photoToDelete.value
+	photoToDelete.value = null
+	if (photo !== null) {
+		await store.dispatch('deleteFiles', [photo.fileid])
+	}
+}
+</script>
+
+<style lang="scss" scoped>
+.duplicates {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+
+	&__empty-content {
+		flex: 1;
+	}
+
+	&__list {
+		margin: 0;
+		padding: calc(var(--default-grid-baseline) * 4);
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--default-grid-baseline) * 6);
+	}
+
+	&__group__title {
+		display: flex;
+		align-items: baseline;
+		gap: calc(var(--default-grid-baseline) * 2);
+		margin: 0 0 calc(var(--default-grid-baseline) * 2);
+		font-weight: bold;
+	}
+
+	&__group__meta {
+		color: var(--color-text-maxcontrast);
+		font-weight: normal;
+		font-size: 0.9em;
+	}
+
+	&__group__grid {
+		margin: 0;
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+		gap: calc(var(--default-grid-baseline) * 3);
+	}
+
+	&__photo {
+		position: relative;
+		aspect-ratio: 1;
+		border-radius: var(--border-radius-large);
+		overflow: hidden;
+		background-color: var(--color-background-dark);
+
+		&__open {
+			width: 100%;
+			height: 100%;
+			padding: 0;
+			border: none;
+			background: none;
+			cursor: pointer;
+		}
+
+		&__image {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+
+		// Revealed on hover or keyboard focus, never hidden behind hover alone.
+		&__delete {
+			position: absolute;
+			inset-block-start: calc(var(--default-grid-baseline) * 1);
+			inset-inline-end: calc(var(--default-grid-baseline) * 1);
+			opacity: 0;
+			transition: opacity var(--animation-quick) ease-out;
+		}
+
+		&:hover &__delete,
+		&:focus-within &__delete {
+			opacity: 1;
+		}
+	}
+}
+
+@media (hover: none) {
+	// No hover on touch, so keep the delete button always visible there.
+	.duplicates__photo__delete {
+		opacity: 1;
+	}
+}
+</style>


### PR DESCRIPTION
## What

Adds a **Duplicates** view that finds and groups duplicate photos so the extra copies can be removed. It's opened from a **"Find duplicate photos"** button in a **Tools** section of the Photos settings (no main-navigation entry).

## How it detects duplicates

Two photos are treated as duplicates when they share an **exact byte size**. Two different images compressing to the very same byte count is astronomically unlikely, so this reliably catches re-uploaded copies **without hashing file contents** (no backend, no ML) — using `oc:size`, which the app already fetches. Pixel dimensions are deliberately *not* part of the match: they're only filled in by a background metadata job, so keying on them would miss a freshly added copy. The user reviews each group before deleting anything.

## The view

- Groups are ordered by copy count then file size, so the biggest space savings surface first; each shows its shared size and the copies side by side.
- A copy can be **opened in the viewer** (with the rest of the group as the viewer's list, to compare) or **moved to the trash** after a confirmation dialog — the group then updates live (and disappears once one copy remains). Deletion goes to the Nextcloud trash (recoverable) via the same store action the timeline uses.
- The grouping logic is a small pure `src/utils/duplicates.ts` with unit tests; the view reuses the existing `useLoadedPhotos` composable, `HeaderNavigation`, and `NcEmptyContent` — modelled on `MemoriesView`.

## Scope / limitations

- Operates on the loaded photo set (the same 500-photo batch the other non-timeline views use), consistent with Places/Faces/Memories.
- Byte size is a strong, safe heuristic rather than a content hash; because the user reviews and confirms each deletion, a rare false grouping is harmless. A future refinement could add a real checksum when one is available.

## Verification

`npm test` (75 tests, incl. 5 new), `npm run lint`, and `npm run build` are clean for the changed files; the pre-existing repo-wide `ts:check` errors are in unrelated files (this change adds none, verified against a clean `master`). Verified on a dev instance with seeded byte-identical copies: opening **Photos settings → Find duplicate photos** closes settings and opens the Duplicates view, which groups the copies ("2 copies · 103 KB"); the delete confirmation names the file and the group updates to "No duplicates found" after deletion — no console errors.

Source only; `js`/`css` will need the usual asset compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)