### PR TITLE
feat: add captions, descriptions and star ratings

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -14,6 +14,18 @@ return [
 			'verb' => 'PUT',
 		],
 		[
+			'name' => 'metadata#get',
+			'url' => '/api/v1/metadata/{fileId}',
+			'verb' => 'GET',
+			'requirements' => ['fileId' => '\d+'],
+		],
+		[
+			'name' => 'metadata#update',
+			'url' => '/api/v1/metadata/{fileId}',
+			'verb' => 'PUT',
+			'requirements' => ['fileId' => '\d+'],
+		],
+		[
 			'name' => 'api#serviceWorker',
 			'url' => '/service-worker.js',
 			'verb' => 'GET',

--- a/lib/Controller/MetadataController.php
+++ b/lib/Controller/MetadataController.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Photos\Controller;
+
+use OCA\Photos\AppInfo\Application;
+use OCA\Photos\DB\PhotoMetadata;
+use OCA\Photos\DB\PhotoMetadataMapper;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\Attribute\NoAdminRequired;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\Constants;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Stores and returns user-editable photo details (description, rating).
+ *
+ * Access is always scoped to the current user's own files: a file id is only
+ * ever resolved through that user's folder, so a caller can neither read nor
+ * write details for a file they cannot see, and writing additionally requires
+ * update permission on the file. CSRF protection is kept on the write.
+ */
+class MetadataController extends Controller {
+	public function __construct(
+		IRequest $request,
+		private readonly PhotoMetadataMapper $mapper,
+		private readonly IRootFolder $rootFolder,
+		private readonly IUserSession $userSession,
+	) {
+		parent::__construct(Application::APP_ID, $request);
+	}
+
+	#[NoAdminRequired]
+	public function get(int $fileId): JSONResponse {
+		if ($this->getAccessibleNode($fileId) === null) {
+			return new JSONResponse(['message' => 'File not found'], Http::STATUS_NOT_FOUND);
+		}
+
+		return new JSONResponse($this->findOrEmpty($fileId));
+	}
+
+	#[NoAdminRequired]
+	public function update(int $fileId, ?string $description = null, ?int $rating = null): JSONResponse {
+		$node = $this->getAccessibleNode($fileId);
+		if ($node === null) {
+			return new JSONResponse(['message' => 'File not found'], Http::STATUS_NOT_FOUND);
+		}
+
+		if (($node->getPermissions() & Constants::PERMISSION_UPDATE) === 0) {
+			return new JSONResponse(['message' => 'No permission to edit this file'], Http::STATUS_FORBIDDEN);
+		}
+
+		if ($rating !== null && ($rating < 0 || $rating > 5)) {
+			return new JSONResponse(['message' => 'Rating must be between 0 and 5'], Http::STATUS_BAD_REQUEST);
+		}
+
+		$entity = $this->mapper->findByFileId($fileId);
+		$isNew = $entity === null;
+		if ($entity === null) {
+			$entity = new PhotoMetadata();
+			$entity->setFileId($fileId);
+		}
+
+		if ($description !== null) {
+			// An empty description is stored as "no description" rather than "".
+			$entity->setDescription($description === '' ? null : $description);
+		}
+		if ($rating !== null) {
+			$entity->setRating($rating);
+		}
+
+		$isNew ? $this->mapper->insert($entity) : $this->mapper->update($entity);
+
+		return new JSONResponse($entity);
+	}
+
+	/** The stored details, or an empty set so the response shape stays stable. */
+	private function findOrEmpty(int $fileId): PhotoMetadata {
+		$entity = $this->mapper->findByFileId($fileId);
+		if ($entity !== null) {
+			return $entity;
+		}
+
+		$empty = new PhotoMetadata();
+		$empty->setFileId($fileId);
+		return $empty;
+	}
+
+	/** The file for the id, only if the current user can actually access it. */
+	private function getAccessibleNode(int $fileId): ?Node {
+		$user = $this->userSession->getUser();
+		if ($user === null) {
+			return null;
+		}
+
+		$nodes = $this->rootFolder->getUserFolder($user->getUID())->getById($fileId);
+		return $nodes[0] ?? null;
+	}
+}

--- a/lib/DB/PhotoMetadata.php
+++ b/lib/DB/PhotoMetadata.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Photos\DB;
+
+use JsonSerializable;
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * User-editable details for a photo, keyed by its file id.
+ *
+ * @method int getFileId()
+ * @method void setFileId(int $fileId)
+ * @method string|null getDescription()
+ * @method void setDescription(?string $description)
+ * @method int getRating()
+ * @method void setRating(int $rating)
+ */
+class PhotoMetadata extends Entity implements JsonSerializable {
+	protected int $fileId = 0;
+	protected ?string $description = null;
+	protected int $rating = 0;
+
+	public function __construct() {
+		$this->addType('fileId', 'integer');
+		$this->addType('rating', 'integer');
+	}
+
+	#[\Override]
+	public function jsonSerialize(): array {
+		return [
+			'fileId' => $this->fileId,
+			'description' => $this->description,
+			'rating' => $this->rating,
+		];
+	}
+}

--- a/lib/DB/PhotoMetadataMapper.php
+++ b/lib/DB/PhotoMetadataMapper.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Photos\DB;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+/**
+ * @extends QBMapper<PhotoMetadata>
+ */
+class PhotoMetadataMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'photos_metadata', PhotoMetadata::class);
+	}
+
+	/**
+	 * The stored details for a file, or null when none have been saved yet.
+	 */
+	public function findByFileId(int $fileId): ?PhotoMetadata {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('file_id', $qb->createNamedParameter($fileId, IQueryBuilder::PARAM_INT)));
+
+		try {
+			return $this->findEntity($qb);
+		} catch (DoesNotExistException) {
+			return null;
+		}
+	}
+}

--- a/lib/Migration/Version33000Date20260825000000.php
+++ b/lib/Migration/Version33000Date20260825000000.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Photos\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Store user-editable photo details (description and rating) that Nextcloud does
+ * not keep anywhere else, keyed by file id.
+ */
+class Version33000Date20260825000000 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure(): ISchemaWrapper $schemaClosure
+	 * @param array $options
+	 */
+	#[\Override]
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('photos_metadata')) {
+			return null;
+		}
+
+		$table = $schema->createTable('photos_metadata');
+		$table->addColumn('id', Types::BIGINT, [
+			'autoincrement' => true,
+			'notnull' => true,
+		]);
+		$table->addColumn('file_id', Types::BIGINT, [
+			'notnull' => true,
+		]);
+		$table->addColumn('description', Types::TEXT, [
+			'notnull' => false,
+		]);
+		$table->addColumn('rating', Types::SMALLINT, [
+			'notnull' => true,
+			'default' => 0,
+		]);
+		$table->setPrimaryKey(['id']);
+		// One row of details per file.
+		$table->addUniqueIndex(['file_id'], 'photos_meta_fileid_idx');
+
+		return $schema;
+	}
+}

--- a/src/components/PhotoMetadataDialog.vue
+++ b/src/components/PhotoMetadataDialog.vue
@@ -10,7 +10,15 @@
 		<NcLoadingIcon v-if="exifEntries === undefined" :size="32" class="photo-metadata__loading" />
 
 		<template v-else>
+			<p v-if="details?.description" class="photo-metadata__description">
+				{{ details.description }}
+			</p>
+
 			<dl class="photo-metadata">
+				<div v-if="details && details.rating > 0" class="photo-metadata__entry">
+					<dt>{{ t('photos', 'Rating') }}</dt>
+					<dd><StarRating :rating="details.rating" readonly :size="18" /></dd>
+				</div>
 				<div class="photo-metadata__entry">
 					<dt>{{ t('photos', 'Filename') }}</dt>
 					<dd>{{ photo.basename }}</dd>
@@ -45,6 +53,7 @@
 </template>
 
 <script lang="ts" setup>
+import type { PhotoDetails } from '../services/photoDetails.ts'
 import type { PhotoExif } from '../utils/exif.ts'
 import type { PhotoTarget } from '../utils/fileUtils.ts'
 
@@ -52,7 +61,9 @@ import { translate as t } from '@nextcloud/l10n'
 import { computed, defineAsyncComponent, onMounted, ref } from 'vue'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import StarRating from './StarRating.vue'
 import { fetchPhotoExif } from '../services/exifFetcher.ts'
+import { getPhotoDetails } from '../services/photoDetails.ts'
 import { formatCoordinates, getExifSummary, getPhotoLocation } from '../utils/exif.ts'
 
 const props = defineProps<{
@@ -70,17 +81,32 @@ const LocationMap = defineAsyncComponent(() => import('./LocationMap.vue'))
 /** Metadata of the photo, `undefined` while it is being fetched. */
 const metadata = ref<PhotoExif | undefined>()
 
+/** Description and rating of the photo, `undefined` while being fetched. */
+const details = ref<PhotoDetails | undefined>()
+
 const exifEntries = computed(() => metadata.value === undefined ? undefined : getExifSummary(metadata.value))
 const location = computed(() => metadata.value === undefined ? null : getPhotoLocation(metadata.value.gps))
 
-// The EXIF properties are not part of the file listings, they are only fetched
-// once the user asks for them.
+// Neither the EXIF properties nor the description and rating are part of the
+// file listings, they are only fetched once the user asks for them.
 onMounted(async () => {
-	metadata.value = await fetchPhotoExif(props.photo)
+	const [exif, photoDetails] = await Promise.all([
+		fetchPhotoExif(props.photo),
+		getPhotoDetails(props.photo.fileid),
+	])
+	details.value = photoDetails
+	metadata.value = exif
 })
 </script>
 
 <style lang="scss" scoped>
+.photo-metadata__description {
+	margin: 0 0 calc(var(--default-grid-baseline) * 3);
+	white-space: pre-wrap;
+	word-break: break-word;
+	color: var(--color-main-text);
+}
+
 .photo-metadata {
 	margin: 0;
 

--- a/src/components/PhotoMetadataEditDialog.vue
+++ b/src/components/PhotoMetadataEditDialog.vue
@@ -11,6 +11,21 @@
 		<NcLoadingIcon v-if="loading" :size="32" class="metadata-editor__loading" />
 
 		<form v-else class="metadata-editor" @submit.prevent="save">
+			<fieldset class="metadata-editor__details">
+				<legend>{{ t('photos', 'Description and rating') }}</legend>
+
+				<NcTextArea
+					v-model="description"
+					:label="t('photos', 'Description')"
+					:placeholder="t('photos', 'Add a description…')"
+					resize="vertical" />
+
+				<div class="metadata-editor__details__rating">
+					<span class="metadata-editor__details__rating__label">{{ t('photos', 'Rating') }}</span>
+					<StarRating :rating="rating" @change="rating = $event" />
+				</div>
+			</fieldset>
+
 			<NcDateTimePickerNative
 				v-model="takenAt"
 				type="datetime-local"
@@ -78,10 +93,13 @@ import NcButton from '@nextcloud/vue/components/NcButton'
 import NcDateTimePickerNative from '@nextcloud/vue/components/NcDateTimePickerNative'
 import NcDialog from '@nextcloud/vue/components/NcDialog'
 import NcLoadingIcon from '@nextcloud/vue/components/NcLoadingIcon'
+import NcTextArea from '@nextcloud/vue/components/NcTextArea'
 import NcTextField from '@nextcloud/vue/components/NcTextField'
 import MapMarkerOffOutline from 'vue-material-design-icons/MapMarkerOffOutline.vue'
+import StarRating from './StarRating.vue'
 import { fetchPhotoExif } from '../services/exifFetcher.ts'
 import logger from '../services/logger.ts'
+import { getPhotoDetails, savePhotoDetails } from '../services/photoDetails.ts'
 import store from '../store/index.ts'
 import { COORDINATE_LIMITS, getPhotoLocation, parseCoordinate } from '../utils/exif.ts'
 
@@ -103,13 +121,18 @@ const saving = ref(false)
 const takenAt = ref<Date | null>(null)
 const latitude = ref('')
 const longitude = ref('')
+const description = ref('')
+const rating = ref(0)
 
-// Neither the coordinates nor the taken date the server holds are part of the
-// file listings, so they are fetched before they can be edited.
+// Neither the coordinates and taken date nor the description and rating are part
+// of the file listings, so they are all fetched before they can be edited.
 onMounted(async () => {
-	const metadata = await fetchPhotoExif(props.photo)
-	const location = getPhotoLocation(metadata.gps)
+	const [metadata, details] = await Promise.all([
+		fetchPhotoExif(props.photo),
+		getPhotoDetails(props.photo.fileid),
+	])
 
+	const location = getPhotoLocation(metadata.gps)
 	if (location !== null) {
 		latitude.value = String(location.latitude)
 		longitude.value = String(location.longitude)
@@ -118,6 +141,9 @@ onMounted(async () => {
 	// Photos always carry a taken date, at worst the one of their upload, but
 	// a photo whose metadata was never extracted has none to show.
 	takenAt.value = metadata.takenAt === undefined ? new Date() : new Date(metadata.takenAt * 1000)
+
+	description.value = details.description ?? ''
+	rating.value = details.rating
 
 	loading.value = false
 })
@@ -177,11 +203,17 @@ async function save(): Promise<void> {
 	saving.value = true
 
 	try {
-		await store.dispatch('updatePhotoMetadata', {
-			photo: props.photo,
-			takenAt: Math.floor(date.getTime() / 1000),
-			location: location.value,
-		})
+		await Promise.all([
+			store.dispatch('updatePhotoMetadata', {
+				photo: props.photo,
+				takenAt: Math.floor(date.getTime() / 1000),
+				location: location.value,
+			}),
+			savePhotoDetails(props.photo.fileid, {
+				description: description.value,
+				rating: rating.value,
+			}),
+		])
 		emit('close')
 	} catch (error) {
 		logger.error('Error saving the metadata of a photo', { error, filename: props.photo.basename })
@@ -200,6 +232,29 @@ async function save(): Promise<void> {
 
 	&__loading {
 		margin: calc(var(--default-grid-baseline) * 4) auto;
+	}
+
+	&__details {
+		display: flex;
+		flex-direction: column;
+		gap: calc(var(--default-grid-baseline) * 2);
+		margin: 0;
+		padding: 0;
+		border: none;
+
+		legend {
+			color: var(--color-text-maxcontrast);
+		}
+
+		&__rating {
+			display: flex;
+			align-items: center;
+			gap: calc(var(--default-grid-baseline) * 2);
+
+			&__label {
+				color: var(--color-text-maxcontrast);
+			}
+		}
 	}
 
 	&__location {

--- a/src/components/StarRating.vue
+++ b/src/components/StarRating.vue
@@ -1,0 +1,83 @@
+<!--
+  - SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+
+<template>
+	<div class="star-rating" role="group" :aria-label="t('photos', 'Rating')">
+		<button
+			v-for="star in 5"
+			:key="star"
+			type="button"
+			class="star-rating__star"
+			:class="{ 'star-rating__star--set': star <= rating }"
+			:disabled="readonly"
+			:aria-label="n('photos', 'Rate {star} star', 'Rate {star} stars', star, { star })"
+			:aria-pressed="star <= rating"
+			@click="select(star)">
+			<Star v-if="star <= rating" :size="size" />
+			<StarOutline v-else :size="size" />
+		</button>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import { translatePlural as n, translate as t } from '@nextcloud/l10n'
+import Star from 'vue-material-design-icons/Star.vue'
+import StarOutline from 'vue-material-design-icons/StarOutline.vue'
+
+const props = withDefaults(defineProps<{
+	/** Current rating, 0 (none) to 5. */
+	rating: number
+	/** Show the stars without allowing changes. */
+	readonly?: boolean
+	size?: number
+}>(), {
+	readonly: false,
+	size: 24,
+})
+
+const emit = defineEmits<{
+	(event: 'change', value: number): void
+}>()
+
+/**
+ * Emit the new rating, clearing it when the current rating is clicked again.
+ *
+ * @param star - The star that was clicked, 1 to 5
+ */
+function select(star: number): void {
+	emit('change', star === props.rating ? 0 : star)
+}
+</script>
+
+<style lang="scss" scoped>
+.star-rating {
+	display: inline-flex;
+	gap: 2px;
+
+	&__star {
+		display: inline-flex;
+		padding: 2px;
+		border: none;
+		border-radius: var(--border-radius);
+		background: none;
+		color: var(--color-text-maxcontrast);
+		cursor: pointer;
+
+		&--set {
+			color: var(--color-favorite);
+		}
+
+		&:disabled {
+			cursor: default;
+		}
+
+		&:not(:disabled):hover,
+		&:not(:disabled):focus-visible {
+			color: var(--color-favorite);
+			background-color: var(--color-background-hover);
+		}
+	}
+}
+</style>

--- a/src/services/photoDetails.ts
+++ b/src/services/photoDetails.ts
@@ -1,0 +1,44 @@
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import axios from '@nextcloud/axios'
+import { generateUrl } from '@nextcloud/router'
+
+/** User-editable details of a photo that Nextcloud does not store elsewhere. */
+export type PhotoDetails = {
+	fileId: number
+	description: string | null
+	rating: number
+}
+
+/**
+ * Fetch the stored description and rating of a photo. A photo that has none
+ * comes back with an empty description and a rating of 0.
+ *
+ * @param fileId - File id of the photo
+ */
+export async function getPhotoDetails(fileId: number): Promise<PhotoDetails> {
+	const { data } = await axios.get<PhotoDetails>(generateUrl('/apps/photos/api/v1/metadata/{fileId}', { fileId }))
+	return data
+}
+
+/**
+ * Save the description and/or rating of a photo. Only the given fields change.
+ *
+ * @param fileId - File id of the photo
+ * @param details - The fields to update
+ * @param details.description - Description, or an empty string / null to clear it
+ * @param details.rating - Rating from 0 (none) to 5
+ */
+export async function savePhotoDetails(
+	fileId: number,
+	details: { description?: string | null, rating?: number },
+): Promise<PhotoDetails> {
+	const { data } = await axios.put<PhotoDetails>(
+		generateUrl('/apps/photos/api/v1/metadata/{fileId}', { fileId }),
+		details,
+	)
+	return data
+}


### PR DESCRIPTION
## What

Adds user-editable **descriptions/captions** and **star ratings** to photos. Nextcloud stores neither in an editable way today (the metadata index only exposes date/time and GPS as writable), so this adds a small store for them in the Photos app and surfaces it in the existing metadata dialogs.

- **Edit metadata** dialog gains a description field and a 0–5 star rating.
- **View metadata** dialog shows the description and the rating.

## Storage & API (backend)

- A new `photos_metadata` table holds `{ file_id, description, rating }`, one row per file (migration + `PhotoMetadata` entity + `PhotoMetadataMapper`).
- A `MetadataController` exposes `GET`/`PUT /api/v1/metadata/{fileId}`. **Access is always scoped to the current user's own files:** a file id is only ever resolved through `getUserFolder()->getById()`, so a caller can neither read nor write details for a file they cannot see (→ 404), and writing additionally requires `PERMISSION_UPDATE` on the file (→ 403). CSRF protection is kept on the write; ratings are validated to 0–5.
- Metadata is stored in the app's DB (like albums), **not** written into the image/EXIF — so it doesn't travel with the file outside Nextcloud. This was a deliberate choice over server-side EXIF/XMP writing (which would need exiftool and modify user files); noted here as the main trade-off.

## Frontend

- A small `photoDetails` service (axios) and a reusable `StarRating` component (uses `--color-favorite`, so it stays legible in dark mode).
- The two dialogs fetch the details alongside the EXIF they already load, and the edit dialog saves them next to the date/GPS update.

## Verification

`composer psalm` and `composer cs:check` are clean; `php -l` passes; `npm run lint`, `npm run build`, and `npm test` (65) are clean for the changed files (the pre-existing repo-wide `ts:check` errors are in unrelated files). Verified end-to-end on a dev instance: the API round-trips and rejects an out-of-range rating (400); editing a photo's description + rating persists and shows up in **View metadata** — no console errors.

Source only; `js`/`css` will need the usual asset compile.

### Possible follow-ups
- Clean up the row on file deletion (a `NodeDeletedEvent` listener) to avoid orphan rows.
- A PHPUnit test for the controller's permission/validation logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)