### PR TITLE
feat: allow the default user config to be set server-wide

### DIFF
--- a/lib/Service/UserConfigService.php
+++ b/lib/Service/UserConfigService.php
@@ -11,6 +11,7 @@ namespace OCA\Photos\Service;
 use Exception;
 use OCA\Photos\AppInfo\Application;
 use OCP\Config\IUserConfig;
+use OCP\IAppConfig;
 use OCP\IUserSession;
 
 class UserConfigService {
@@ -23,6 +24,7 @@ class UserConfigService {
 	];
 
 	public function __construct(
+		private readonly IAppConfig $appConfig,
 		private readonly IUserConfig $userConfig,
 		private readonly IUserSession $userSession,
 	) {
@@ -38,7 +40,7 @@ class UserConfigService {
 			throw new Exception('Unknown user config key');
 		}
 
-		$default = self::DEFAULT_CONFIGS[$key];
+		$default = $this->appConfig->getValueString(Application::APP_ID, 'default_' . $key, self::DEFAULT_CONFIGS[$key]);
 		$value = $this->userConfig->getValueString($userId, Application::APP_ID, $key, $default);
 
 		return $value;


### PR DESCRIPTION
Fixes #3796

### Summary

The per-user Photos settings resolve their fallback from `UserConfigService::DEFAULT_CONFIGS`, a class constant. That leaves an administrator with only the per-user value to set, which covers existing accounts if you loop over every user but does nothing for accounts created afterwards. On a server whose users all work in one non-English language, `/Photos` ends up being the one folder name they cannot read, and patching the app is the only way to change it.

This resolves the fallback from an app config value first, keeping the constant as the last resort:

```php
$default = $this->appConfig->getValueString(Application::APP_ID, 'default_' . $key, self::DEFAULT_CONFIGS[$key]);
$value = $this->userConfig->getValueString($userId, Application::APP_ID, $key, $default);
```

so an administrator can run

```
occ config:app:set photos default_photosLocation --value="/Fotoğraflar"
occ config:app:set photos default_photosSourceFolders --value='["/Fotoğraflar"]'
```

It is the same shape Talk uses for its attachment folder (`default_attachment_folder` in `spreed/lib/Config.php`), and it covers every key in `DEFAULT_CONFIGS` rather than the folder ones alone.

### Behaviour

- A server that sets no app config behaves exactly as before.
- A user who picked their own value still wins over the administrator's default.
- Only the fallback changes; nothing is written or migrated.

### Note for administrators

Worth being explicit about, because it caught us: accounts that never opened the Photos settings have no stored value, so they follow the default. Changing `default_photosSourceFolders` on a running server therefore moves what those accounts see. Listing both folders (`["/Fotoğraflar","/Photos"]`) keeps existing media visible while new uploads go to the new folder. I mentioned an `occ` command that could carry that migration in #3796; happy to follow up with one if you would like it.

### Testing

Built and running on Nextcloud 34 with the equivalent change against the bundled Photos version, on a server with several thousand accounts. New accounts get the configured folder, accounts with their own value keep it, and unsetting the app config restores the previous behaviour.
