### PR TITLE
Honor EXIF OffsetTimeOriginal

### DIFF
--- a/lib/Listener/ExifMetadataProvider.php
+++ b/lib/Listener/ExifMetadataProvider.php
@@ -230,7 +230,16 @@ class ExifMetadataProvider implements IEventListener {
 	private function sanitizeEntries(array $data, File $node): array {
 		$cleanData = [];
 
+		// PHP's EXIF extension reports the OffsetTime tags using their numeric tag IDs.
+		$knownExifTags = [
+			'UndefinedTag:0x9010' => 'OffsetTime',
+			'UndefinedTag:0x9011' => 'OffsetTimeOriginal',
+			'UndefinedTag:0x9012' => 'OffsetTimeDigitized',
+		];
+
 		foreach ($data as $key => $value) {
+			$key = $knownExifTags[$key] ?? $key;
+
 			if (is_string($value) && !mb_check_encoding($value, 'UTF-8')) {
 				$value = 'base64:' . base64_encode($value);
 			} elseif (is_string($value)) {

--- a/lib/Listener/OriginalDateTimeMetadataProvider.php
+++ b/lib/Listener/OriginalDateTimeMetadataProvider.php
@@ -36,7 +36,6 @@ class OriginalDateTimeMetadataProvider implements IEventListener {
 
 	private function dateToTimestamp(string $format, string $date, File $node): int|false {
 		try {
-			// Note: We do not have the timezone when parsing the date, so the timestamp will be off by X hours.
 			$dateTime = DateTime::createFromFormat($format, $date);
 			if ($dateTime !== false && $dateTime->getTimestamp() > 0) {
 				return $dateTime->getTimestamp();
@@ -86,8 +85,23 @@ class OriginalDateTimeMetadataProvider implements IEventListener {
 			$metadata->hasKey(ExifMetadataProvider::METADATA_KEY_EXIF)
 			&& !empty($metadata->getArray(ExifMetadataProvider::METADATA_KEY_EXIF)['DateTimeOriginal'])
 		) {
-			$rawDateTimeOriginal = $metadata->getArray(ExifMetadataProvider::METADATA_KEY_EXIF)['DateTimeOriginal'];
-			$timestampOriginal = $this->dateToTimestamp('Y:m:d G:i:s', $rawDateTimeOriginal, $node);
+			$exif = $metadata->getArray(ExifMetadataProvider::METADATA_KEY_EXIF);
+			$rawDateTimeOriginal = $exif['DateTimeOriginal'];
+			$offsetTimeOriginal = $exif['OffsetTimeOriginal'] ?? null;
+
+			if (is_string($offsetTimeOriginal) && $offsetTimeOriginal !== '') {
+				$timestampOriginal = $this->dateToTimestamp(
+					'Y:m:d G:i:sP',
+					$rawDateTimeOriginal . $offsetTimeOriginal,
+					$node,
+				);
+			} else {
+				$timestampOriginal = false;
+			}
+
+			if ($timestampOriginal === false) {
+				$timestampOriginal = $this->dateToTimestamp('Y:m:d G:i:s', $rawDateTimeOriginal, $node);
+			}
 			if ($timestampOriginal !== false) {
 				$metadata->setInt(self::METADATA_KEY, $timestampOriginal, true);
 				return;

--- a/tests/Listener/ExifMetadataProviderTest.php
+++ b/tests/Listener/ExifMetadataProviderTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Photos\Tests\Listener;
+
+use OCA\Photos\Listener\ExifMetadataProvider;
+use OCP\Files\File;
+use Psr\Log\LoggerInterface;
+use ReflectionMethod;
+use Test\TestCase;
+
+class ExifMetadataProviderTest extends TestCase {
+	public function testPreservesKnownOffsetTimeTags(): void {
+		$logger = $this->createMock(LoggerInterface::class);
+		$provider = new ExifMetadataProvider($logger);
+
+		$node = $this->createMock(File::class);
+
+		$method = new ReflectionMethod($provider, 'sanitizeEntries');
+		$method->setAccessible(true);
+
+		$result = $method->invoke(
+			$provider,
+			[
+				'UndefinedTag:0x9010' => '+09:00',
+				'UndefinedTag:0x9011' => '+09:00',
+				'UndefinedTag:0x9012' => '+09:00',
+			],
+			$node,
+		);
+
+		$this->assertSame(
+			[
+				'OffsetTime' => '+09:00',
+				'OffsetTimeOriginal' => '+09:00',
+				'OffsetTimeDigitized' => '+09:00',
+			],
+			$result,
+		);
+	}
+}

--- a/tests/Listener/OriginalDateTimeMetadataProviderTest.php
+++ b/tests/Listener/OriginalDateTimeMetadataProviderTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Photos\Tests\Listener;
+
+use OCA\Photos\Listener\ExifMetadataProvider;
+use OCA\Photos\Listener\OriginalDateTimeMetadataProvider;
+use OCP\Files\File;
+use OCP\Files\Storage\IStorage;
+use OCP\FilesMetadata\Event\MetadataLiveEvent;
+use OCP\FilesMetadata\Model\IFilesMetadata;
+use Psr\Log\LoggerInterface;
+use Test\TestCase;
+
+class OriginalDateTimeMetadataProviderTest extends TestCase {
+	public function testUsesOffsetTimeOriginal(): void {
+		$this->assertOriginalDateTime(
+			'2025:11:30 16:43:51',
+			'+09:00',
+			1764488631,
+		);
+	}
+
+	public function testUsesNegativeOffsetTimeOriginal(): void {
+		$this->assertOriginalDateTime(
+			'2025:11:30 16:43:51',
+			'-05:00',
+			1764539031,
+		);
+	}
+
+	private function assertOriginalDateTime(
+		string $dateTimeOriginal,
+		string $offsetTimeOriginal,
+		int $expectedTimestamp,
+	): void {
+		$storage = $this->createMock(IStorage::class);
+		$storage->method('isLocal')->willReturn(true);
+
+		$file = $this->createMock(File::class);
+		$file->method('getStorage')->willReturn($storage);
+		$file->method('getMimeType')->willReturn('image/jpeg');
+
+		$metadata = $this->createMock(IFilesMetadata::class);
+		$metadata
+			->method('hasKey')
+			->with(ExifMetadataProvider::METADATA_KEY_EXIF)
+			->willReturn(true);
+		$metadata
+			->method('getArray')
+			->with(ExifMetadataProvider::METADATA_KEY_EXIF)
+			->willReturn([
+				'DateTimeOriginal' => $dateTimeOriginal,
+				'OffsetTimeOriginal' => $offsetTimeOriginal,
+			]);
+
+		$metadata
+			->expects($this->once())
+			->method('setInt')
+			->with(
+				OriginalDateTimeMetadataProvider::METADATA_KEY,
+				$expectedTimestamp,
+				true,
+			)
+			->willReturnSelf();
+
+		$logger = $this->createMock(LoggerInterface::class);
+		$provider = new OriginalDateTimeMetadataProvider($logger);
+
+		$event = new MetadataLiveEvent($file, $metadata);
+		$provider->handle($event);
+	}
+}


### PR DESCRIPTION
## Summary

Honor EXIF `OffsetTimeOriginal` when generating `photos-original_date_time`.

PHP's EXIF extension exposes EXIF timezone tags 0x9010, 0x9011, and 0x9012 as undefined numeric tags. These were previously sanitized to the same key, so the timezone information was effectively lost.

This change:

- maps EXIF tags 0x9010/0x9011/0x9012 to `OffsetTime`, `OffsetTimeOriginal`, and `OffsetTimeDigitized`
- combines `DateTimeOriginal` with `OffsetTimeOriginal` when creating the timestamp
- falls back to the previous timezone-less parsing behavior if no usable offset is available
- adds unit tests for positive and negative offsets and for preservation of the EXIF offset tags

## Example

For a photo with:

```text
DateTimeOriginal: 2025:11:30 16:43:51
OffsetTimeOriginal: +09:00
```

the previous code stored:

```text
1764521031
```

which corresponds to interpreting the local capture time as UTC.

With this change, it stores:

```text
1764488631
```

which represents the correct instant.

## Tests

- Added unit tests for EXIF offset tag mapping
- Added unit tests for `OffsetTimeOriginal` handling with `+09:00` and `-05:00`
- Full Photos PHPUnit suite passes: `10 tests, 15 assertions`

Related to nextcloud/viewer#2753  
Related to nextcloud/photos#3592