### PR TITLE
test(e2e): wait for the playable video to get its turn in the slideshow

### DIFF
--- a/tests/playwright/e2e/slideshow.spec.ts
+++ b/tests/playwright/e2e/slideshow.spec.ts
@@ -86,6 +86,13 @@ test.describe('The slideshow of the timeline', () => {
 })
 
 test.describe('The slideshow of the videos view', () => {
+	/**
+	 * The view leads with the newest video, which is not the playable one, so the
+	 * slideshow only reaches that one after a turn: the first video plays out and
+	 * the slide is counted down before moving on.
+	 */
+	const SLIDESHOW_TURN = 15_000
+
 	test.beforeEach(async ({ photosApp, seedVideos }) => {
 		await seedVideos()
 		await photosApp.timeline.open(Timeline.videos)
@@ -94,7 +101,7 @@ test.describe('The slideshow of the videos view', () => {
 	test('plays the video rather than showing a still of it', async ({ photosApp }) => {
 		const slideshow = await photosApp.timeline.startSlideshow()
 
-		await slideshow.waitForPhoto(PLAYABLE_VIDEO)
+		await slideshow.waitForPhoto(PLAYABLE_VIDEO, { timeout: SLIDESHOW_TURN })
 		// Held first, so that the slideshow does not move on while the player is
 		// being looked at.
 		await slideshow.pause()
@@ -112,7 +119,7 @@ test.describe('The slideshow of the videos view', () => {
 	test('holds on the video until it has played out', async ({ photosApp }) => {
 		const slideshow = await photosApp.timeline.startSlideshow()
 
-		await slideshow.waitForPhoto(PLAYABLE_VIDEO)
+		await slideshow.waitForPhoto(PLAYABLE_VIDEO, { timeout: SLIDESHOW_TURN })
 
 		// The slide is not counted down while the video plays, or a video longer
 		// than the delay of the slideshow would be cut off in the middle.

--- a/tests/playwright/support/sections/ViewerModal.ts
+++ b/tests/playwright/support/sections/ViewerModal.ts
@@ -94,9 +94,10 @@ export class ViewerModal {
 	 * Wait for the viewer to show a photo.
 	 *
 	 * @param name - Name of the photo file it is expected to open on
+	 * @param options - How long to wait, when the photo is due later than a load
 	 */
-	public async waitForPhoto(name: string): Promise<void> {
-		await expect(this.heading(name)).toBeVisible()
+	public async waitForPhoto(name: string, options?: { timeout: number }): Promise<void> {
+		await expect(this.heading(name)).toBeVisible(options)
 	}
 
 	/**


### PR DESCRIPTION
`slideshow.spec.ts:94` and `:112` have failed on every run since 3fc145b03 (#3826 was merged with Playwright red):

```
Error: expect(locator).toBeVisible() failed
Locator: locator('.viewer').getByRole('heading', { name: 'VID_20191024_081301.mp4' })
Timeout: 5000ms
```

The videos view lists the newest video first, and of the two fixtures that is the quicktime one. The slideshow opens on it, and only moves on to the mp4 the tests are about once that first slide is over: the video plays out (2 s), then the slide is counted down (`slideshowDelay`, 5 s). The tests looked for the mp4 heading right away and gave up before it came.

They now wait for its turn, through a `timeout` option on `ViewerModal.waitForPhoto`. Checked locally with three repeats of the two tests, 6/6.

*👾 This pull request was assisted by Claude Code, commits carry an `Assisted-by` trailer.*
